### PR TITLE
v1.1.0 - IPv6 stack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 **sondare** is a Python CLI tool for auditing local networks, built on top of [Scapy](https://scapy.net/). It provides scanning and fingerprinting methods, each running with multithreaded packet dispatch for speed.
 
-- **ARP** — discovers all active hosts on the local subnet (cannot be blocked by firewalls)
+- **ARP** — discovers all active IPv4 hosts on the local subnet (cannot be blocked by firewalls)
+- **NDP** — discovers IPv6 hosts on the local link via ICMPv6 multicast ping + neighbor cache
 - **ICMP** — pings all hosts to check reachability (iOS devices block ICMP by design; use ARP for full discovery)
 - **TCP** — performs a SYN scan on a target host to find open ports; optionally grabs service banners
 - **UDP** — probes UDP ports; reports open (got a UDP reply) or open|filtered (no response) ports
@@ -53,7 +54,8 @@ sudo sondare <command> [options]
 
 | Command | Description |
 | --------- | ------------- |
-| `arp` | ARP scan of the local subnet |
+| `arp` | ARP scan of the local subnet (IPv4) |
+| `ndp` | NDP scan of the local link (IPv6) |
 | `ping` | ICMP scan of the local subnet |
 | `tcp` | TCP SYN port scan of a target host |
 | `udp` | UDP port scan of a target host |
@@ -75,6 +77,15 @@ sudo sondare arp
 
 # Discover hosts and resolve their hostnames (requires PTR records on the network)
 sudo sondare arp --resolve_hostname
+
+# Discover IPv6 hosts on the local link via NDP
+sudo sondare ndp
+
+# NDP scan with a longer timeout (useful on slower networks)
+sudo sondare ndp -t 5
+
+# NDP with hostname resolution
+sudo sondare ndp --resolve_hostname
 
 # Discover live hosts via ICMP with 10s timeout
 sudo sondare ping -t 10
@@ -153,6 +164,7 @@ sudo sondare tls --target 192.168.1.1:8443
 
 # Output results as JSON (supported by all scan commands)
 sudo sondare arp --json
+sudo sondare ndp --json
 sudo sondare ping --json
 sudo sondare tcp --target 192.168.1.1:1-1024 --banners --json
 sudo sondare mdns --json
@@ -171,6 +183,12 @@ arp:
 ping:
   -t, --timeout          Packet timeout in seconds (default: 5)
   --resolve_hostname     Resolve hostnames via mDNS, SSDP, NetBIOS, and PTR
+  -v, --verbose          Verbose scapy output
+  --json                 JSON output
+
+ndp:
+  -t, --timeout          Scan timeout in seconds (default: 3)
+  --resolve_hostname     Resolve hostnames via PTR lookup
   -v, --verbose          Verbose scapy output
   --json                 JSON output
 
@@ -245,3 +263,5 @@ tls:
 ```
 
 > **Note:** `trace` uses ICMP echo probes. Hosts that block ICMP will show `*` for all hops.
+>
+> **Note:** `ndp` sends ICMPv6 echo requests to the all-nodes multicast `ff02::1` and merges results with the OS NDP neighbor cache. Hosts that block ICMPv6 pings may still appear via the cache if they were recently reachable.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - **OS fingerprinting** — guesses the OS of a host by analysing TTL and TCP window size in a SYN-ACK response
 - **TLS/SSL probing** — extracts certificate details (CN, issuer, validity, SANs) from HTTPS ports; flags expired and self-signed certs
 - **Hostname resolution** — resolves hostnames via mDNS service browse, SSDP/UPnP, NetBIOS, and PTR records
+- **Network graph** — renders an interactive HTML topology of the local network via dual-stack ARP + NDP discovery, with optional OS fingerprinting and vendor labels per node
 
 ## Requirements
 
@@ -61,10 +62,11 @@ sudo sondare <command> [options]
 | `udp` | UDP port scan of a target host |
 | `os` | OS fingerprint of a target host |
 | `monitor arp` | Watch for ARP traffic; report new hosts and MAC changes |
-| `monitor hosts` | Live host reachability table with auto-discovery |
-| `monitor ports` | Periodically SYN-scan a target and report port state changes |
+| `monitor ndp` | Watch for ICMPv6 Neighbor Advertisements; report new IPv6 hosts and MAC changes |
+| `monitor hosts` | Live host reachability table with auto-discovery (IPv4 and IPv6) |
+| `monitor ports` | Periodically SYN-scan a target and report port state changes (IPv4 and IPv6) |
 | `monitor traffic` | Live packet capture with per-packet protocol breakdown |
-| `graph` | Generate an interactive HTML network graph of the local subnet |
+| `graph` | Generate an interactive HTML network graph via ARP + NDP dual-stack discovery |
 | `mdns` | Discover mDNS/Bonjour services on the local network |
 | `trace` | Trace the network path to a target host |
 | `tls` | Probe TLS/SSL certificate details on a target host |
@@ -114,8 +116,14 @@ sudo sondare tcp --target 192.168.1.1:80
 # Grab service banners from open ports
 sudo sondare tcp --target 192.168.1.1:1-1024 --banners
 
+# Scan an IPv6 host (quote brackets to prevent shell glob expansion)
+sudo sondare tcp --target '[fe80::dead:beef]:1-1024'
+
 # UDP scan of common ports
 sudo sondare udp --target 192.168.1.1:1-1024
+
+# UDP scan of an IPv6 host
+sudo sondare udp --target '[fe80::dead:beef]:1-1024'
 
 # Fingerprint a host OS (auto-probes common ports)
 sudo sondare os --target 192.168.1.1
@@ -123,17 +131,26 @@ sudo sondare os --target 192.168.1.1
 # Fingerprint using a known-open port
 sudo sondare os --target 192.168.1.1 --port 80
 
+# Fingerprint an IPv6 host
+sudo sondare os --target fe80::dead:beef
+
 # Watch for new hosts and ARP spoofing attempts
 sudo sondare monitor arp
+
+# Watch for new IPv6 hosts and NDP spoofing (neighbor cache poisoning) attempts
+sudo sondare monitor ndp
 
 # Monitor all hosts on the subnet (auto-discovers new/departed hosts)
 sudo sondare monitor hosts
 
-# Monitor specific hosts every 10s
-sudo sondare monitor hosts --hosts 192.168.1.1 192.168.1.50 -i 10
+# Monitor specific hosts every 10s (IPv6 addresses are detected automatically)
+sudo sondare monitor hosts --hosts 192.168.1.1 fe80::dead:beef -i 10
 
 # Watch for port state changes on a target
 sudo sondare monitor ports --target 192.168.1.1:1-1024
+
+# Watch ports on an IPv6 target
+sudo sondare monitor ports --target '[fe80::dead:beef]:1-1024'
 
 # Live packet capture (all traffic)
 sudo sondare monitor traffic
@@ -158,6 +175,9 @@ sudo sondare trace --target 8.8.8.8
 
 # Trace with a longer per-hop timeout and a cap of 20 hops
 sudo sondare trace --target 8.8.8.8 -t 5 --max-hops 20
+
+# Trace to an IPv6 host
+sudo sondare trace --target fe80::dead:beef
 
 # Discover mDNS/Bonjour services (AirPlay, SSH, SMB, Chromecast, HomeKit, …)
 sudo sondare mdns
@@ -204,7 +224,8 @@ ndp:
   --json                 JSON output
 
 tcp:
-  --target          Target as ip, ip:port, or ip:start-end (default: local machine, ports 1-1000)
+  --target          Target as ip, ip:port, or ip:start-end; IPv6 with ports: '[fe80::1]:80'
+                    (quote brackets in shell); default: local machine, ports 1-1000
   -t, --timeout     Packet timeout in seconds (default: 3)
   -th, --threads    Number of threads (default: 20)
   -r, --retries     Retries per port on no response (default: 2)
@@ -213,14 +234,15 @@ tcp:
   --json            JSON output
 
 udp:
-  --target          Target as ip, ip:port, or ip:start-end (default: local machine, ports 1-1000)
+  --target          Target as ip, ip:port, or ip:start-end; IPv6 with ports: '[fe80::1]:80'
+                    (quote brackets in shell); default: local machine, ports 1-1000
   -t, --timeout     Packet timeout in seconds (default: 3)
   -th, --threads    Number of threads (default: 20)
   -r, --retries     Retries per port on no response (default: 2)
   -v, --verbose     Verbose scapy output
 
 os:
-  --target          Target IP address (required)
+  --target          Target IPv4 or IPv6 address (required)
   --port            Port to probe; omit to auto-try common ports in parallel
   -t, --timeout     Timeout per probe in seconds (default: 3)
   -v, --verbose     Verbose scapy output
@@ -229,15 +251,21 @@ monitor arp:
   -t, --timeout     Timeout for initial ARP seed scan (default: 5)
   -v, --verbose     Verbose scapy output
 
+monitor ndp:
+  -t, --timeout     Timeout for initial ICMPv6 multicast seed sweep (default: 5)
+  -v, --verbose     Verbose scapy output
+
 monitor hosts:
-  --hosts           Hosts to monitor; omit to auto-discover via ARP each round
+  --hosts           Hosts to monitor; IPv4 and IPv6 addresses accepted; omit to
+                    auto-discover via ARP each round
   -i, --interval    Seconds between ping rounds (default: 30)
   -t, --timeout     Ping timeout in seconds (default: 2)
   -th, --threads    Concurrent pings per round (default: 50)
   -v, --verbose     Verbose scapy output
 
 monitor ports:
-  --target          Target as ip, ip:port, or ip:start-end (default: local machine, ports 1-1000)
+  --target          Target as ip, ip:port, or ip:start-end; IPv6 with ports: '[fe80::1]:80'
+                    (quote brackets in shell); default: local machine, ports 1-1000
   -i, --interval    Seconds between scans (default: 60)
   -t, --timeout     Timeout per probe in seconds (default: 3)
   -th, --threads    Concurrent probes per scan (default: 20)
@@ -250,7 +278,7 @@ monitor traffic:
 graph:
   --fingerprint     OS-fingerprint each discovered host (TCP SYN, falls back to ICMP TTL)
   -o, --output      Output path: .html for interactive graph, .json for topology data (default: sondare_graph.html)
-  -t, --timeout     ARP scan timeout in seconds (default: 3)
+  -t, --timeout     ARP + NDP scan timeout in seconds (default: 3)
   -th, --threads    Concurrent fingerprint probes (default: 10)
   -v, --verbose     Verbose scapy output
 
@@ -260,19 +288,23 @@ mdns:
   --json            JSON output
 
 trace:
-  --target          Target IP address (required)
+  --target          Target IPv4 or IPv6 address (required)
   -t, --timeout     Timeout per hop in seconds (default: 3)
   --max-hops        Maximum number of hops (default: 30)
   -v, --verbose     Verbose scapy output
   --json            JSON output
 
 tls:
-  --target          Target as ip or ip:port (default ports: 443, 8443)
+  --target          Target as ip or ip:port; IPv6 with port: '[fe80::1]:443'
+                    (quote brackets in shell); default ports: 443, 8443
   -t, --timeout     Connection timeout in seconds (default: 5)
   -v, --verbose     Verbose mode
   --json            JSON output
 ```
 
-> **Note:** `trace` uses ICMP echo probes. Hosts that block ICMP will show `*` for all hops.
->
-> **Note:** `ndp` sends ICMPv6 echo requests to the all-nodes multicast `ff02::1` and merges results with the OS NDP neighbor cache. Hosts that block ICMPv6 pings may still appear via the cache if they were recently reachable.
+## Notes
+
+- **`trace`** uses ICMP/ICMPv6 echo probes. Hosts that block ICMP will show `*` for all hops.
+- **`ndp` / `monitor ndp`** send ICMPv6 echo requests to the all-nodes multicast `ff02::1` and merge results with the OS NDP neighbor cache. Hosts that block ICMPv6 pings may still appear via the cache if they were recently reachable.
+- **`graph`** runs ARP and NDP discovery in parallel. Devices with both IPv4 and IPv6 addresses are merged by MAC and appear as a single node in the graph.
+- **IPv6 with ports** — use bracket notation and quote it to prevent shell glob expansion: `'[fe80::1]:443'`. Applies to `tcp`, `udp`, `monitor ports`, and `tls`.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ sudo sondare ping -t 10
 # Ping scan with hostname resolution
 sudo sondare ping --resolve_hostname
 
+# Probe a specific IPv6 host
+sudo sondare ping --target fe80::dead:beef
+
 # Note: iOS devices block ICMP by design and won't appear in ping results.
 # Use `sondare arp` for complete host discovery including iOS devices.
 
@@ -181,6 +184,7 @@ arp:
   --json                 JSON output
 
 ping:
+  --target               IPv6 host to probe; omit to scan the full local IPv4 subnet
   -t, --timeout          Packet timeout in seconds (default: 5)
   --resolve_hostname     Resolve hostnames via mDNS, SSDP, NetBIOS, and PTR
   -v, --verbose          Verbose scapy output

--- a/README.md
+++ b/README.md
@@ -93,8 +93,14 @@ sudo sondare ping -t 10
 # Ping scan with hostname resolution
 sudo sondare ping --resolve_hostname
 
-# Probe a specific IPv6 host
+# Probe a single IPv4 host
+sudo sondare ping --target 192.168.1.1
+
+# Probe a single IPv6 host
 sudo sondare ping --target fe80::dead:beef
+
+# Scan all IPv6 hosts on the local link via ICMPv6 multicast
+sudo sondare ping --ipv6
 
 # Note: iOS devices block ICMP by design and won't appear in ping results.
 # Use `sondare arp` for complete host discovery including iOS devices.
@@ -184,11 +190,12 @@ arp:
   --json                 JSON output
 
 ping:
-  --target               IPv6 host to probe; omit to scan the full local IPv4 subnet
-  -t, --timeout          Packet timeout in seconds (default: 5)
-  --resolve_hostname     Resolve hostnames via mDNS, SSDP, NetBIOS, and PTR
-  -v, --verbose          Verbose scapy output
-  --json                 JSON output
+  --target           Single host to probe (IPv4 or IPv6); omit to scan the local IPv4 subnet
+  --ipv6             ICMPv6 multicast sweep of ff02::1 (all IPv6 hosts on the local link)
+  -t, --timeout      Packet timeout in seconds (default: 5)
+  --resolve_hostname Resolve hostnames via mDNS, SSDP, NetBIOS, and PTR
+  -v, --verbose      Verbose scapy output
+  --json             JSON output
 
 ndp:
   -t, --timeout          Scan timeout in seconds (default: 3)

--- a/sondare/main.py
+++ b/sondare/main.py
@@ -35,38 +35,87 @@ class Target(NamedTuple):
     port_end: int
 
 
-_TARGET_RE = re.compile(r"([^:]+)(?::(\d+)(?:-(\d+))?)?")
 _DEFAULT_PORT_BEGIN = 1
 _DEFAULT_PORT_END = 1000
 
+# Bracket IPv6 with optional port range: [fe80::1] or [fe80::1]:80 or [fe80::1]:80-443
+_IPV6_BRACKET_RE = re.compile(r"\[([^\]]+)\](?::(\d+)(?:-(\d+))?)?")
+# IPv4 / hostname with optional port range
+_IPV4_RE = re.compile(r"([^:]+)(?::(\d+)(?:-(\d+))?)?")
+
+
+def _parse_port_range(port_str: str | None, end_str: str | None, value: str) -> tuple[int, int]:
+    if port_str is None:
+        return _DEFAULT_PORT_BEGIN, _DEFAULT_PORT_END
+    start = int(port_str)
+    end   = int(end_str) if end_str else start
+    if start < 1 or end > 65535:
+        raise argparse.ArgumentTypeError(f"Port out of range (1-65535) in '{value}'.")
+    if start > end:
+        raise argparse.ArgumentTypeError(f"Start port {start} must be <= end port {end} in '{value}'.")
+    return start, end
+
 
 def parse_target(value: str) -> Target:
-    """Parses 'ip', 'ip:port', or 'ip:start-end' into a Target."""
-    match = _TARGET_RE.fullmatch(value)
-    if not match:
-        raise argparse.ArgumentTypeError(f"Invalid target format: '{value}'. Expected ip, ip:port, or ip:start-end.")
-    ip = match.group(1)
-    if match.group(2) is None:
-        return Target(ip, _DEFAULT_PORT_BEGIN, _DEFAULT_PORT_END)
-    start = int(match.group(2))
-    end = int(match.group(3)) if match.group(3) else start
-    if start < 1:
-        raise argparse.ArgumentTypeError(f"Port {start} out of range (1-65535).")
-    if start > end:
-        raise argparse.ArgumentTypeError(f"Start port {start} must be <= end port {end}.")
-    if end > 65535:
-        raise argparse.ArgumentTypeError(f"Port {end} out of range (1-65535).")
+    """Parses 'ip', 'ip:port', 'ip:start-end', '[ipv6]', '[ipv6]:port', or '[ipv6]:start-end'."""
+    import ipaddress as _ia
+    if value.startswith("["):
+        m = _IPV6_BRACKET_RE.fullmatch(value)
+        if not m:
+            raise argparse.ArgumentTypeError(f"Invalid target format: '{value}'.")
+        ip = m.group(1)
+        start, end = _parse_port_range(m.group(2), m.group(3), value)
+    else:
+        # Bare IPv6 without brackets (no port can be specified this way)
+        try:
+            addr = _ia.ip_address(value)
+            if isinstance(addr, _ia.IPv6Address):
+                return Target(value, _DEFAULT_PORT_BEGIN, _DEFAULT_PORT_END)
+        except ValueError:
+            pass
+        # Detect bare IPv6 + port suffix and suggest bracket notation.
+        # Strip a trailing :port or :start-end and test if the remainder is valid IPv6.
+        m_suffix = re.match(r"^(.+):(\d+(?:-\d+)?)$", value)
+        if m_suffix:
+            try:
+                candidate = _ia.ip_address(m_suffix.group(1))
+                if isinstance(candidate, _ia.IPv6Address):
+                    raise argparse.ArgumentTypeError(
+                        f"IPv6 addresses with ports require bracket notation: "
+                        f"[{m_suffix.group(1)}]:{m_suffix.group(2)}"
+                    )
+            except ValueError:
+                pass
+        m = _IPV4_RE.fullmatch(value)
+        if not m:
+            raise argparse.ArgumentTypeError(f"Invalid target format: '{value}'.")
+        ip = m.group(1)
+        start, end = _parse_port_range(m.group(2), m.group(3), value)
     return Target(ip, start, end)
 
 
 def _parse_tls_target(value: str) -> tuple[str, tuple[int, ...]]:
-    """Parses 'ip' or 'ip:port' into (ip, ports). Defaults to DEFAULT_PORTS when no port given."""
-    m = re.fullmatch(r"([^:]+)(?::(\d+))?", value)
-    if not m:
-        raise argparse.ArgumentTypeError(f"Invalid target: '{value}'")
-    ip = m.group(1)
-    if m.group(2) is not None:
-        port = int(m.group(2))
+    """Parses 'ip', '[ipv6]', 'ip:port', or '[ipv6]:port' into (ip, ports)."""
+    import ipaddress as _ia
+    if value.startswith("["):
+        m = re.fullmatch(r"\[([^\]]+)\](?::(\d+))?", value)
+        if not m:
+            raise argparse.ArgumentTypeError(f"Invalid target: '{value}'")
+        ip, port_str = m.group(1), m.group(2)
+    else:
+        # Bare IPv6 without port
+        try:
+            addr = _ia.ip_address(value)
+            if isinstance(addr, _ia.IPv6Address):
+                return value, _TLS_DEFAULT_PORTS
+        except ValueError:
+            pass
+        m = re.fullmatch(r"([^:]+)(?::(\d+))?", value)
+        if not m:
+            raise argparse.ArgumentTypeError(f"Invalid target: '{value}'")
+        ip, port_str = m.group(1), m.group(2)
+    if port_str is not None:
+        port = int(port_str)
         if not (1 <= port <= 65535):
             raise argparse.ArgumentTypeError(f"Port {port} out of range (1-65535).")
         return ip, (port,)
@@ -198,7 +247,7 @@ tls:
 
     # TCP scan
     tcp_parser = subparsers.add_parser("tcp", parents=[shared], help="Scan ports of target host with TCP packets.")
-    tcp_parser.add_argument("--target", type=parse_target, default=None, help="Target in the form ip, ip:port, or ip:start-end (default: local machine, ports 1-1000)")
+    tcp_parser.add_argument("--target", type=parse_target, default=None, help="Target as ip, ip:port, or ip:start-end. IPv6 with ports: '[fe80::1]:80' (quote brackets in shell)")
     tcp_parser.add_argument("-t", "--timeout", type=int, default=3, help="Timeout for port scan (default: 3)")
     tcp_parser.add_argument("-th", "--threads", type=int, default=20, help="Amount of threads to use")
     tcp_parser.add_argument("-r", "--retries", type=int, default=2, help="Retries per port on no response (default: 2)")
@@ -212,7 +261,7 @@ tls:
 
     # UDP scan
     udp_parser = subparsers.add_parser("udp", parents=[shared], help="Scan ports of target host with UDP packets.")
-    udp_parser.add_argument("--target", type=parse_target, default=None, help="Target in the form ip, ip:port, or ip:start-end (default: local machine, ports 1-1000)")
+    udp_parser.add_argument("--target", type=parse_target, default=None, help="Target as ip, ip:port, or ip:start-end. IPv6 with ports: '[fe80::1]:80' (quote brackets in shell)")
     udp_parser.add_argument("-t", "--timeout", type=int, default=3, help="Timeout for port scan (default: 3)")
     udp_parser.add_argument("-th", "--threads", type=int, default=20, help="Amount of threads to use")
     udp_parser.add_argument("-r", "--retries", type=int, default=2, help="Retries per port on no response (default: 2)")
@@ -231,7 +280,7 @@ tls:
     updown_parser.add_argument("-th", "--threads", type=int, default=50, help="Concurrent pings per round (default: 50)")
 
     ports_parser = monitor_sub.add_parser("ports", parents=[shared], help="Periodically SYN-scan a target and report port state changes.")
-    ports_parser.add_argument("--target", type=parse_target, default=None, help="Target as ip, ip:port, or ip:start-end (default: local machine, ports 1-1000)")
+    ports_parser.add_argument("--target", type=parse_target, default=None, help="Target as ip, ip:port, or ip:start-end. IPv6 with ports: '[fe80::1]:80' (quote brackets in shell)")
     ports_parser.add_argument("-i", "--interval", type=int, default=60, help="Seconds between scans (default: 60)")
     ports_parser.add_argument("-t", "--timeout", type=float, default=3.0, help="Timeout per probe in seconds (default: 3)")
     ports_parser.add_argument("-th", "--threads", type=int, default=20, help="Concurrent probes per scan (default: 20)")
@@ -248,7 +297,7 @@ tls:
 
     # TLS probe
     tls_parser = subparsers.add_parser("tls", parents=[shared], help="Probe TLS/SSL certificate details on a target host.")
-    tls_parser.add_argument("--target", required=True, help="Target as ip or ip:port (default ports: 443, 8443)")
+    tls_parser.add_argument("--target", required=True, help="Target as ip or ip:port. IPv6 with port: '[fe80::1]:443' (quote brackets in shell)")
     tls_parser.add_argument("-t", "--timeout", type=float, default=5.0, help="Connection timeout in seconds (default: 5)")
 
     # mDNS scan

--- a/sondare/main.py
+++ b/sondare/main.py
@@ -25,6 +25,7 @@ from sondare.services.trace import Traceroute
 from sondare.services.tls import TlsProber, DEFAULT_PORTS as _TLS_DEFAULT_PORTS
 from sondare.monitors.arp_watcher import ArpWatcher
 from sondare.monitors.hosts_watcher import HostsWatcher
+from sondare.monitors.ndp_watcher import NdpWatcher
 from sondare.monitors.port_watcher import PortWatcher
 from sondare.monitors.traffic_sniffer import TrafficSniffer
 
@@ -177,6 +178,10 @@ monitor arp:
   -t, --timeout     Timeout for initial ARP seed scan (default: 5)
   -v, --verbose     Verbose scapy output
 
+monitor ndp:
+  -t, --timeout     Timeout for initial multicast seed sweep (default: 5)
+  -v, --verbose     Verbose scapy output
+
 monitor hosts:
   --hosts           Hosts to monitor; omit to auto-discover via ARP
   -i, --interval    Seconds between ping rounds (default: 30)
@@ -271,7 +276,9 @@ tls:
     monitor_sub = monitor_parser.add_subparsers(title="MONITOR TYPES", dest="monitor_type")
 
     arp_watch_parser = monitor_sub.add_parser("arp", parents=[shared], help="Watch for ARP traffic and report new hosts or MAC changes.")
+    ndp_watch_parser = monitor_sub.add_parser("ndp", parents=[shared], help="Watch for ICMPv6 Neighbor Advertisements and report new IPv6 hosts or MAC changes.")
     arp_watch_parser.add_argument("-t", "--timeout", type=int, default=5, help="Timeout for initial ARP seed scan (default: 5)")
+    ndp_watch_parser.add_argument("-t", "--timeout", type=int, default=5, help="Timeout for initial multicast seed sweep (default: 5)")
 
     updown_parser = monitor_sub.add_parser("hosts", parents=[shared], help="Periodically ping hosts and report up/down state changes.")
     updown_parser.add_argument("--hosts", nargs="+", metavar="IP", default=None, help="Hosts to monitor (default: discover via ARP scan)")
@@ -508,10 +515,13 @@ def main() -> None:
 
         elif args.scan_method == "monitor":
             if args.monitor_type is None:
-                print("Usage: sondare monitor {arp,hosts,ports,traffic}\nRun 'sondare monitor <type> --help' for details.")
+                print("Usage: sondare monitor {arp,ndp,hosts,ports,traffic}\nRun 'sondare monitor <type> --help' for details.")
                 return
             if args.monitor_type == "arp":
                 watcher = ArpWatcher(verbose=args.verbose, timeout=args.timeout)
+                watcher.watch()
+            elif args.monitor_type == "ndp":
+                watcher = NdpWatcher(verbose=args.verbose, timeout=args.timeout)
                 watcher.watch()
             elif args.monitor_type == "hosts":
                 monitor = HostsWatcher(

--- a/sondare/main.py
+++ b/sondare/main.py
@@ -14,6 +14,7 @@ logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
 import sondare.utils.network as network
 import sondare.utils.root as root
 from sondare.services.arp import Arp
+from sondare.services.ndp import Ndp
 from sondare.services.icmp import Ping
 from sondare.services.tcp import Tcp
 from sondare.services.udp import Udp
@@ -93,8 +94,8 @@ def parse_args() -> argparse.ArgumentParser:
         description=f"sondare {_get_version()} — Probe and monitor local network hosts.",
         formatter_class=argparse.RawTextHelpFormatter,
         epilog="""
-arp / ping:
-  -t, --timeout          Packet timeout in seconds (default: 5)
+arp / ping / ndp:
+  -t, --timeout          Packet timeout in seconds (default: 5 for arp/ping, 3 for ndp)
   --resolve_hostname     Resolve hostnames via mDNS, SSDP, NetBIOS, and PTR
   -v, --verbose          Verbose scapy output
   --json                 JSON output
@@ -182,6 +183,11 @@ tls:
     arp_parser = subparsers.add_parser("arp", parents=[shared], help="Scan local network with ARP packets.")
     arp_parser.add_argument("-t", "--timeout", type=int, default=5, help="Timeout for scan response")
     arp_parser.add_argument("--resolve_hostname", action="store_true", help="Resolve hostnames via PTR lookup")
+
+    # NDP scan
+    ndp_parser = subparsers.add_parser("ndp", parents=[shared], help="Discover IPv6 hosts via Neighbor Discovery Protocol.")
+    ndp_parser.add_argument("-t", "--timeout", type=int, default=3, help="Timeout in seconds (default: 3)")
+    ndp_parser.add_argument("--resolve_hostname", action="store_true", help="Resolve hostnames via PTR lookup")
 
     # Ping scan
     ping_parser = subparsers.add_parser("ping", parents=[shared], help="Ping all hosts in local network with ICMP packets.")
@@ -288,13 +294,45 @@ def main() -> None:
                 ]}))
             else:
                 if args.resolve_hostname:
-                    print("IP".ljust(15) + "HOSTNAME".ljust(30) + "MAC".ljust(20) + "VENDOR")
+                    host_col = max((len(h.hostname or '') for h in results), default=8) + 2
+                    mac_col  = max((len(h.mac) for h in results), default=17) + 2
+                    print("IP".ljust(15) + "HOSTNAME".ljust(host_col) + "MAC".ljust(mac_col) + "VENDOR")
                     for h in results:
-                        print(f"{h.ip.ljust(15)}{(h.hostname or '').ljust(30)}{h.mac.ljust(20)}{h.vendor or ''}")
+                        print(f"{h.ip.ljust(15)}{(h.hostname or '').ljust(host_col)}{h.mac.ljust(mac_col)}{h.vendor or ''}")
                 else:
                     print("IP".ljust(15) + "MAC".ljust(20) + "VENDOR")
                     for h in results:
                         print(f"{h.ip.ljust(15)}{h.mac.ljust(20)}{h.vendor or ''}")
+
+        elif args.scan_method == "ndp":
+            print(f"Running NDP scan with {args.timeout}s timeout")
+            scanner = Ndp(verbose=args.verbose, timeout=args.timeout, resolve_hostname=args.resolve_hostname)
+            scanner.scan()
+            results = scanner.get_results()
+
+            if args.json:
+                print(json.dumps({"hosts": [
+                    {
+                        "ip": h.ip,
+                        "mac": h.mac,
+                        **({"hostname": h.hostname} if args.resolve_hostname else {}),
+                        **({"vendor": h.vendor} if h.vendor else {}),
+                    }
+                    for h in results
+                ]}))
+            else:
+                ip_col = max((len(h.ip) for h in results), default=4) + 2
+                if args.resolve_hostname:
+                    host_col = max((len(h.hostname or '') for h in results), default=8) + 2
+                    mac_col  = max((len(h.mac) for h in results), default=17) + 2
+                    print("IPv6".ljust(ip_col) + "HOSTNAME".ljust(host_col) + "MAC".ljust(mac_col) + "VENDOR")
+                    for h in results:
+                        print(f"{h.ip.ljust(ip_col)}{(h.hostname or '').ljust(host_col)}{h.mac.ljust(mac_col)}{h.vendor or ''}")
+                else:
+                    mac_col = max((len(h.mac) for h in results), default=17) + 2
+                    print("IPv6".ljust(ip_col) + "MAC".ljust(mac_col) + "VENDOR")
+                    for h in results:
+                        print(f"{h.ip.ljust(ip_col)}{h.mac.ljust(mac_col)}{h.vendor or ''}")
 
         elif args.scan_method == "ping":
             print(f"Running ICMP scan on {network.get_network_interface()} with {args.timeout}s timeout")

--- a/sondare/main.py
+++ b/sondare/main.py
@@ -193,6 +193,7 @@ tls:
     ping_parser = subparsers.add_parser("ping", parents=[shared], help="Ping all hosts in local network with ICMP packets.")
     ping_parser.add_argument("-t", "--timeout", type=int, default=5, help="Timeout for scan response")
     ping_parser.add_argument("--resolve_hostname", action="store_true", help="Resolve hostnames via PTR lookup")
+    ping_parser.add_argument("--target", type=str, default=None, help="IPv6 target to probe; omit to scan the full local IPv4 subnet")
 
     # TCP scan
     tcp_parser = subparsers.add_parser("tcp", parents=[shared], help="Scan ports of target host with TCP packets.")
@@ -335,8 +336,17 @@ def main() -> None:
                         print(f"{h.ip.ljust(ip_col)}{h.mac.ljust(mac_col)}{h.vendor or ''}")
 
         elif args.scan_method == "ping":
-            print(f"Running ICMP scan on {network.get_network_interface()} with {args.timeout}s timeout")
-            scanner = Ping(verbose=args.verbose, timeout=args.timeout, resolve_hostname=args.resolve_hostname)
+            if args.target:
+                import ipaddress as _ipaddress
+                try:
+                    _ipaddress.ip_address(args.target)
+                except ValueError:
+                    print(f"Error: '{args.target}' is not a valid IP address.", file=sys.stderr)
+                    sys.exit(1)
+                print(f"Pinging {args.target} with {args.timeout}s timeout")
+            else:
+                print(f"Running ICMP scan on {network.get_network_interface()} with {args.timeout}s timeout")
+            scanner = Ping(verbose=args.verbose, timeout=args.timeout, resolve_hostname=args.resolve_hostname, target=args.target)
             scanner.scan()
             results = scanner.get_results()
 

--- a/sondare/main.py
+++ b/sondare/main.py
@@ -193,7 +193,8 @@ tls:
     ping_parser = subparsers.add_parser("ping", parents=[shared], help="Ping all hosts in local network with ICMP packets.")
     ping_parser.add_argument("-t", "--timeout", type=int, default=5, help="Timeout for scan response")
     ping_parser.add_argument("--resolve_hostname", action="store_true", help="Resolve hostnames via PTR lookup")
-    ping_parser.add_argument("--target", type=str, default=None, help="IPv6 target to probe; omit to scan the full local IPv4 subnet")
+    ping_parser.add_argument("--target", type=str, default=None, help="Single host to probe (IPv4 or IPv6); omit to scan the local subnet")
+    ping_parser.add_argument("--ipv6", action="store_true", help="ICMPv6 multicast sweep of ff02::1 (all IPv6 hosts on the local link)")
 
     # TCP scan
     tcp_parser = subparsers.add_parser("tcp", parents=[shared], help="Scan ports of target host with TCP packets.")
@@ -344,9 +345,11 @@ def main() -> None:
                     print(f"Error: '{args.target}' is not a valid IP address.", file=sys.stderr)
                     sys.exit(1)
                 print(f"Pinging {args.target} with {args.timeout}s timeout")
+            elif args.ipv6:
+                print(f"Running ICMPv6 scan on local link with {args.timeout}s timeout")
             else:
                 print(f"Running ICMP scan on {network.get_network_interface()} with {args.timeout}s timeout")
-            scanner = Ping(verbose=args.verbose, timeout=args.timeout, resolve_hostname=args.resolve_hostname, target=args.target)
+            scanner = Ping(verbose=args.verbose, timeout=args.timeout, resolve_hostname=args.resolve_hostname, target=args.target, ipv6=args.ipv6)
             scanner.scan()
             results = scanner.get_results()
 

--- a/sondare/monitors/hosts_watcher.py
+++ b/sondare/monitors/hosts_watcher.py
@@ -4,8 +4,8 @@
 import threading
 import time
 from datetime import datetime
-from scapy.all import IP, ICMP, ARP, Ether, sr1, srp
-from sondare.utils.network import get_subnet, get_network_interface
+from scapy.all import IP, ICMP, IPv6, ICMPv6EchoRequest, ICMPv6EchoReply, ARP, Ether, sr1, srp
+from sondare.utils.network import get_subnet, get_network_interface, is_ipv6_address
 
 
 def _arp_scan(timeout: int, verbose: bool) -> list[str]:
@@ -56,6 +56,14 @@ class HostsWatcher:
         self._last_line_count = 0
 
     def _ping(self, host: str) -> bool:
+        if is_ipv6_address(host):
+            ans = sr1(
+                IPv6(dst=host) / ICMPv6EchoRequest(),
+                timeout=self._timeout,
+                verbose=self._verbose,
+                promisc=False,
+            )
+            return bool(ans and ans.haslayer(ICMPv6EchoReply))
         ans = sr1(
             IP(dst=host) / ICMP(),
             timeout=self._timeout,
@@ -99,17 +107,19 @@ class HostsWatcher:
             print(f"\033[{self._last_line_count}A\033[J", end="", flush=True)
 
     def _draw(self, ts: str) -> None:
+        ip_w = max((len(ip) for ip in self._state), default=14) + 2
+        ip_w = max(ip_w, 4)  # at least wide enough for "IP" header
         lines = [
             f"Host monitor — updated {ts}, interval {self._interval}s (Ctrl+C to stop)",
             "",
-            f"  {'IP':<16}{'Status':<6}  Since",
-            f"  {'─' * 16}{'─' * 6}  {'─' * 8}",
+            f"  {'IP':<{ip_w}}{'Status':<6}  Since",
+            f"  {'─' * ip_w}{'─' * 6}  {'─' * 8}",
         ]
         if self._state:
             for ip in sorted(self._state):
                 is_up, since = self._state[ip]
                 status = "UP  " if is_up else "DOWN"
-                lines.append(f"  {ip:<16}{status}  {since}")
+                lines.append(f"  {ip:<{ip_w}}{status}  {since}")
         else:
             lines.append("  (no hosts found)")
         print("\n".join(lines), flush=True)

--- a/sondare/monitors/ndp_watcher.py
+++ b/sondare/monitors/ndp_watcher.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+import threading
+from datetime import datetime
+from scapy.all import Ether, IPv6, ICMPv6EchoRequest, ICMPv6EchoReply, ICMPv6ND_NA, srp, sniff
+from scapy.packet import Packet
+from sondare.utils.network import get_network_interface, get_ipv6_link_local, read_ndp_cache
+
+_ALL_NODES_MAC  = "33:33:00:00:00:01"
+_ALL_NODES_ADDR = "ff02::1"
+
+
+class NdpWatcher:
+    """
+    Seeds known IPv6 hosts with an initial multicast echo sweep + NDP cache,
+    then passively sniffs ICMPv6 Neighbor Advertisement traffic and prints
+    events as they arrive:
+      NEW     — first time this IPv6 address is seen
+      CHANGED — same address, different MAC (potential NDP spoofing)
+    """
+
+    def __init__(self, verbose: bool, timeout: float) -> None:
+        self.verbose = verbose
+        self._timeout = timeout
+        self._hosts: dict[str, str] = {}  # ipv6 -> mac
+        self._lock = threading.Lock()
+        self._iface = get_network_interface()
+        self._own_ip = (get_ipv6_link_local(self._iface) or "").lower()
+
+    def _seed(self) -> None:
+        print(f"Seeding from ICMPv6 multicast sweep on {self._iface} ...", end=" ", flush=True)
+        pkt = (
+            Ether(dst=_ALL_NODES_MAC)
+            / IPv6(dst=_ALL_NODES_ADDR)
+            / ICMPv6EchoRequest(id=0x5afe, seq=1)
+        )
+        ans = srp(
+            pkt,
+            iface=self._iface,
+            timeout=self._timeout,
+            verbose=self.verbose,
+            promisc=False,
+            multi=True,
+        )[0]
+        for _, rcv in ans:
+            if not rcv.haslayer(ICMPv6EchoReply):
+                continue
+            ip  = rcv[IPv6].src.split("%")[0].lower()
+            mac = rcv[Ether].src.lower()
+            if ip != self._own_ip and not ip.startswith("ff"):
+                self._hosts[ip] = mac
+
+        for ip, mac in read_ndp_cache(self._iface).items():
+            if ip not in self._hosts and ip != self._own_ip and not ip.startswith("ff"):
+                self._hosts[ip] = mac
+
+        print(f"found {len(self._hosts)} host(s)")
+        if self._hosts:
+            ip_w = max(len(ip) for ip in self._hosts) + 2
+            print("  " + "IPv6".ljust(ip_w) + "MAC")
+            for ip, mac in sorted(self._hosts.items()):
+                print(f"  {ip.ljust(ip_w)}{mac}")
+
+    def _handle(self, pkt: Packet) -> None:
+        if not (pkt.haslayer(IPv6) and pkt.haslayer(ICMPv6ND_NA) and pkt.haslayer(Ether)):
+            return
+        ip  = pkt[IPv6].src.split("%")[0].lower()
+        mac = pkt[Ether].src.lower()
+        if not ip or ip == self._own_ip or ip.startswith("ff"):
+            return
+        ts = datetime.now().strftime("%H:%M:%S")
+        with self._lock:
+            if ip not in self._hosts:
+                self._hosts[ip] = mac
+                print(f"[{ts}] NEW     {ip}  {mac}")
+            elif self._hosts[ip] != mac:
+                old_mac = self._hosts[ip]
+                self._hosts[ip] = mac
+                print(f"[{ts}] CHANGED {ip}  {old_mac} -> {mac}  (possible NDP spoofing!)")
+
+    def watch(self) -> None:
+        self._seed()
+        print(f"\nWatching for ICMPv6 Neighbor Advertisements on {self._iface} (Ctrl+C to stop) ...\n")
+        sniff(
+            iface=self._iface,
+            filter="icmp6 and ip6[40] == 136",
+            prn=self._handle,
+            store=False,
+            promisc=False,
+        )

--- a/sondare/monitors/port_watcher.py
+++ b/sondare/monitors/port_watcher.py
@@ -6,8 +6,8 @@ import threading
 import time
 from datetime import datetime
 from queue import Queue
-from scapy.all import IP, TCP, sr1, sr
-from sondare.utils.network import warm_arp_cache
+from scapy.all import IP, IPv6, TCP, sr1, sr
+from sondare.utils.network import warm_arp_cache, is_ipv6_address
 
 
 def _syn_scan(ip: str, port_begin: int, port_end: int, timeout: float, threads: int, verbose: bool) -> set[int]:
@@ -20,17 +20,19 @@ def _syn_scan(ip: str, port_begin: int, port_end: int, timeout: float, threads: 
     open_ports: set[int] = set()
     lock = threading.Lock()
     q: Queue[int] = Queue()
+    ipv6 = is_ipv6_address(ip)
 
     def check(port: int) -> None:
         sport = random.randint(1025, 65534)
+        ip_layer = IPv6(dst=ip) if ipv6 else IP(dst=ip)
         rsp = sr1(
-            IP(dst=ip) / TCP(sport=sport, dport=port, flags="S"),
+            ip_layer / TCP(sport=sport, dport=port, flags="S"),
             timeout=timeout,
             verbose=verbose,
             promisc=False,
         )
         if rsp and rsp.haslayer(TCP) and rsp.getlayer(TCP).flags == 0x12:
-            sr(IP(dst=ip) / TCP(sport=sport, dport=port, flags="R"), timeout=1, verbose=False, promisc=False)
+            sr(ip_layer / TCP(sport=sport, dport=port, flags="R"), timeout=1, verbose=False, promisc=False)
             with lock:
                 open_ports.add(port)
 
@@ -98,7 +100,8 @@ class PortWatcher:
             f"Monitoring ports {port_range} on {self._ip}"
             f" every {self._interval}s — Ctrl+C to stop\n"
         )
-        warm_arp_cache(self._ip)
+        if not is_ipv6_address(self._ip):
+            warm_arp_cache(self._ip)
         first = True
         while True:
             ts = datetime.now().strftime("%H:%M:%S")

--- a/sondare/services/fingerprint.py
+++ b/sondare/services/fingerprint.py
@@ -4,9 +4,9 @@
 import random
 import threading
 import time
-from scapy.all import IP, TCP, ICMP, sr1, sr
+from scapy.all import IP, IPv6, TCP, ICMP, ICMPv6EchoRequest, ICMPv6EchoReply, sr1, sr
 from sondare.models import Fingerprint
-from sondare.utils.network import warm_arp_cache
+from sondare.utils.network import warm_arp_cache, is_ipv6_address
 from sondare.utils.adaptive_pool import AdaptivePool
 
 # Ports tried in parallel when no specific port is given.
@@ -82,6 +82,7 @@ class OsFingerprinter:
         self.port = port
         self._icmp_fallback = icmp_fallback
         self._timeout = timeout
+        self._ipv6 = is_ipv6_address(ip)
         self._pool = AdaptivePool(max_threads=len(_COMMON_PORTS), timeout=timeout)
         self._result: Fingerprint | None = None
         self._lock = threading.Lock()
@@ -89,11 +90,12 @@ class OsFingerprinter:
 
     def _syn_probe(self, sport: int, port: int) -> object:
         """Sends one SYN packet, updates the pool, and returns the response or None."""
+        ip_layer = IPv6(dst=self.ip) if self._ipv6 else IP(dst=self.ip)
         self._pool.acquire()
         try:
             start = time.monotonic()
             rsp = sr1(
-                IP(dst=self.ip) / TCP(sport=sport, dport=port, flags="S"),
+                ip_layer / TCP(sport=sport, dport=port, flags="S"),
                 timeout=self._pool.timeout,
                 verbose=self.verbose,
                 promisc=False,
@@ -126,43 +128,48 @@ class OsFingerprinter:
         with self._lock:
             if self._result is not None:
                 return  # another thread already recorded a result
+            ip_layer = IPv6(dst=self.ip) if self._ipv6 else IP(dst=self.ip)
             sr(
-                IP(dst=self.ip) / TCP(sport=sport, dport=port, flags="R"),
+                ip_layer / TCP(sport=sport, dport=port, flags="R"),
                 timeout=1, verbose=False, promisc=False,
             )
-            tcp  = rsp.getlayer(TCP)
-            opts = _parse_tcp_options(tcp.options)
+            tcp      = rsp.getlayer(TCP)
+            opts     = _parse_tcp_options(tcp.options)
+            ip_resp  = rsp.getlayer(IPv6) if self._ipv6 else rsp.getlayer(IP)
+            ttl      = ip_resp.hlim if self._ipv6 else ip_resp.ttl
             self._result = Fingerprint(
                 ip=self.ip,
-                os=_guess_os(rsp.getlayer(IP).ttl, tcp.window, opts),
-                ttl=rsp.getlayer(IP).ttl,
+                os=_guess_os(ttl, tcp.window, opts),
+                ttl=ttl,
                 window=tcp.window,
                 source="tcp",
             )
             self._found.set()
 
     def _icmp_probe(self) -> None:
-        """Sends one ICMP echo and records OS from TTL alone (window=0 indicates ICMP-derived)."""
-        pkt = sr1(
-            IP(dst=self.ip) / ICMP(),
-            timeout=self._timeout,
-            verbose=self.verbose,
-            promisc=False,
-        )
-        if pkt is not None and pkt.haslayer(IP):
-            ttl = pkt.getlayer(IP).ttl
-            self._result = Fingerprint(
-                ip=self.ip,
-                os=_guess_os(ttl, 0),
-                ttl=ttl,
-                window=0,
-                source="icmp",
+        """Sends one ICMP/ICMPv6 echo and records OS from TTL/hlim alone (window=0 = ICMP-derived)."""
+        if self._ipv6:
+            pkt = sr1(
+                IPv6(dst=self.ip) / ICMPv6EchoRequest(),
+                timeout=self._timeout, verbose=self.verbose, promisc=False,
             )
+            if pkt is not None and pkt.haslayer(ICMPv6EchoReply):
+                hlim = pkt.getlayer(IPv6).hlim
+                self._result = Fingerprint(ip=self.ip, os=_guess_os(hlim, 0), ttl=hlim, window=0, source="icmp")
+        else:
+            pkt = sr1(
+                IP(dst=self.ip) / ICMP(),
+                timeout=self._timeout, verbose=self.verbose, promisc=False,
+            )
+            if pkt is not None and pkt.haslayer(IP):
+                ttl = pkt.getlayer(IP).ttl
+                self._result = Fingerprint(ip=self.ip, os=_guess_os(ttl, 0), ttl=ttl, window=0, source="icmp")
 
     def scan(self) -> None:
         """Probes all ports in parallel; fingerprints on the first SYN-ACK.
         Falls back to ICMP TTL when no TCP port responds (unless icmp_fallback=False)."""
-        warm_arp_cache(self.ip)
+        if not self._ipv6:
+            warm_arp_cache(self.ip)
         ports = [self.port] if self.port is not None else _COMMON_PORTS
         threads = [
             threading.Thread(target=self._probe, args=(port,), daemon=True)

--- a/sondare/services/graph.py
+++ b/sondare/services/graph.py
@@ -4,15 +4,22 @@
 import json
 import os
 import platform
+import psutil
+import socket
 import subprocess
 import threading
 from datetime import datetime
 from importlib.resources import files as _res_files
 
-from scapy.all import ARP, Ether, srp, conf
-from sondare.models import Host
+from scapy.all import ARP, Ether, IPv6, ICMPv6EchoRequest, ICMPv6EchoReply, srp, conf
 from sondare.services.fingerprint import OsFingerprinter
-from sondare.utils.network import get_subnet, get_network_interface, get_ip_address
+from sondare.utils.network import (
+    get_subnet, get_network_interface, get_ip_address,
+    get_ipv6_link_local, read_ndp_cache, get_mac_vendor,
+)
+
+_ALL_NODES_MAC  = "33:33:00:00:00:01"
+_ALL_NODES_ADDR = "ff02::1"
 
 _HTML_TEMPLATE = """\
 <!DOCTYPE html>
@@ -136,10 +143,26 @@ def _get_gateway() -> str | None:
         return None
 
 
+def _get_local_mac(iface: str) -> str | None:
+    """Returns the MAC address of the local network interface."""
+    try:
+        link_family = getattr(psutil, "AF_LINK", getattr(socket, "AF_PACKET", None))
+        if link_family is None:
+            return None
+        for addr in psutil.net_if_addrs().get(iface, []):
+            if addr.family == link_family:
+                return addr.address.lower().replace("-", ":")
+    except Exception:
+        pass
+    return None
+
+
 class NetworkGraph:
     """
-    Discovers hosts via ARP, optionally fingerprints their OS, then renders
-    an interactive HTML network graph using vis-network (bundled, no CDN needed).
+    Discovers hosts via ARP + ICMPv6 multicast (NDP), merges results by MAC
+    so each physical device appears as one node regardless of address family,
+    optionally fingerprints their OS, then renders an interactive HTML network
+    graph using vis-network (bundled, no CDN needed).
     """
 
     def __init__(
@@ -155,10 +178,12 @@ class NetworkGraph:
         self._threads = threads
         self._fingerprint = fingerprint
         self._output = output
-        self._hosts: list[Host] = []
-        self._os_map: dict[str, str] = {}  # ip -> os string
+        self._devices: list[dict] = []  # [{mac, ipv4, ipv6}] — one entry per physical device
+        self._os_map: dict[str, str] = {}      # mac -> os string
+        self._vendor_map: dict[str, str] = {}  # mac -> vendor string
 
-    def _arp_scan(self) -> list[Host]:
+    def _arp_scan(self) -> dict[str, str]:
+        """Returns {mac: ipv4} from ARP broadcast."""
         cidr = get_subnet()
         iface = get_network_interface()
         ans = srp(
@@ -168,13 +193,49 @@ class NetworkGraph:
             verbose=self._verbose,
             promisc=False,
         )[0]
-        return [Host(ip=rcv.psrc, mac=rcv.hwsrc) for _, rcv in ans]
+        return {rcv.hwsrc.lower(): rcv.psrc for _, rcv in ans}
 
-    def _fingerprint_hosts(self, ips: list[str]) -> None:
+    def _ndp_scan(self) -> dict[str, str]:
+        """Returns {mac: ipv6} from ICMPv6 multicast echo + NDP neighbor cache."""
+        iface = get_network_interface()
+        local_v6 = (get_ipv6_link_local(iface) or "").lower()
+        pkt = (
+            Ether(dst=_ALL_NODES_MAC)
+            / IPv6(dst=_ALL_NODES_ADDR)
+            / ICMPv6EchoRequest(id=0x5afe, seq=1)
+        )
+        ans = srp(
+            pkt, iface=iface, timeout=self._timeout, verbose=self._verbose,
+            promisc=False, multi=True,
+        )[0]
+        result: dict[str, str] = {}
+        for _, rcv in ans:
+            if not rcv.haslayer(ICMPv6EchoReply):
+                continue
+            ip  = rcv[IPv6].src.split("%")[0].lower()
+            mac = rcv[Ether].src.lower()
+            if ip != local_v6 and not ip.startswith("ff"):
+                result[mac] = ip
+        for ip, mac in read_ndp_cache(iface).items():
+            if mac not in result and ip != local_v6 and not ip.startswith("ff"):
+                result[mac] = ip
+        return result
+
+    def _merge(self, arp: dict[str, str], ndp: dict[str, str]) -> list[dict]:
+        """Merges ARP and NDP results by MAC — one dict per physical device."""
+        all_macs = set(arp) | set(ndp)
+        return [{"mac": m, "ipv4": arp.get(m), "ipv6": ndp.get(m)} for m in all_macs]
+
+    def _preferred_ip(self, device: dict) -> str:
+        """IPv4 preferred for OS fingerprinting; fall back to IPv6."""
+        return device["ipv4"] or device["ipv6"]
+
+    def _fingerprint_hosts(self, devices: list[dict]) -> None:
         lock = threading.Lock()
         sem = threading.Semaphore(self._threads)
 
-        def probe(ip: str) -> None:
+        def probe(device: dict) -> None:
+            ip = self._preferred_ip(device)
             try:
                 scanner = OsFingerprinter(
                     verbose=self._verbose, ip=ip, port=None, timeout=self._timeout
@@ -183,108 +244,161 @@ class NetworkGraph:
                 result = scanner.get_results()
                 if result:
                     with lock:
-                        self._os_map[ip] = result.os
+                        self._os_map[device["mac"]] = result.os
             except Exception:
                 pass
             finally:
                 sem.release()
 
         threads = []
-        for ip in ips:
+        for device in devices:
             sem.acquire()
-            t = threading.Thread(target=probe, args=(ip,), daemon=True)
+            t = threading.Thread(target=probe, args=(device,), daemon=True)
             t.start()
             threads.append(t)
         for t in threads:
             t.join()
 
     def _build_topology(
-        self, gateway: str | None, local_ip: str, subnet: str, scan_time: str
+        self,
+        gateway: str | None,
+        local_ipv4: str,
+        local_ipv6: str | None,
+        local_mac: str | None,
+        subnet: str,
+        scan_time: str,
     ) -> dict:
-        mac_lookup = {h.ip: h.mac for h in self._hosts}
-        all_ips = {h.ip for h in self._hosts} | {local_ip}
-        if gateway:
-            all_ips.add(gateway)
+        ipv4_to_mac = {d["ipv4"]: d["mac"] for d in self._devices if d["ipv4"]}
+        gw_mac = ipv4_to_mac.get(gateway) if gateway else None
 
-        def _role(ip: str) -> str:
-            if ip == gateway:
+        def _role(d: dict) -> str:
+            if d["mac"] == gw_mac or d["ipv4"] == gateway:
                 return "gateway"
-            if ip == local_ip:
+            if d["mac"] == local_mac or d["ipv4"] == local_ipv4:
                 return "local"
             return "host"
 
         hosts = []
-        for ip in sorted(all_ips):
-            entry: dict = {"ip": ip, "mac": mac_lookup.get(ip, "unknown"), "role": _role(ip)}
-            if ip in self._os_map:
-                entry["os"] = self._os_map[ip]
+        for d in sorted(self._devices, key=lambda x: (x["ipv4"] or x["ipv6"] or "")):
+            entry: dict = {"mac": d["mac"], "role": _role(d)}
+            if d["ipv4"]:
+                entry["ipv4"] = d["ipv4"]
+            if d["ipv6"]:
+                entry["ipv6"] = d["ipv6"]
+            if d["mac"] in self._vendor_map:
+                entry["vendor"] = self._vendor_map[d["mac"]]
+            if d["mac"] in self._os_map:
+                entry["os"] = self._os_map[d["mac"]]
             hosts.append(entry)
+
+        # Ensure local machine appears even when it didn't respond to ARP/NDP
+        local_present = any(
+            h.get("ipv4") == local_ipv4 or h.get("mac") == local_mac
+            for h in hosts
+        )
+        if not local_present:
+            local_entry: dict = {"mac": local_mac or "local", "role": "local", "ipv4": local_ipv4}
+            if local_ipv6:
+                local_entry["ipv6"] = local_ipv6
+            hosts.append(local_entry)
 
         return {
             "subnet": subnet,
             "gateway": gateway,
-            "local_ip": local_ip,
+            "local_ipv4": local_ipv4,
             "scan_time": scan_time,
             "hosts": hosts,
         }
 
     def _build_graph(
-        self, gateway: str | None, local_ip: str
+        self,
+        gateway: str | None,
+        local_ipv4: str,
+        local_ipv6: str | None,
+        local_mac: str | None,
     ) -> tuple[list[dict], list[dict]]:
         nodes: list[dict] = []
         edges: list[dict] = []
-        mac_lookup = {h.ip: h.mac for h in self._hosts}
 
-        def _node(ip: str, group: str, extra_label: str = "") -> dict:
-            mac = mac_lookup.get(ip, "unknown")
-            os_str = self._os_map.get(ip, "")
-            label_parts = [ip, mac]
-            if extra_label:
-                label_parts.append(extra_label)
+        ipv4_to_mac = {d["ipv4"]: d["mac"] for d in self._devices if d["ipv4"]}
+        gw_mac = ipv4_to_mac.get(gateway) if gateway else None
+        local_id = local_mac or local_ipv4  # fallback to IP when MAC unavailable
+
+        def _node(node_id: str, ipv4: str | None, ipv6: str | None, group: str, extra: str = "") -> dict:
+            os_str     = self._os_map.get(node_id, "")
+            vendor_str = self._vendor_map.get(node_id, "")
+            label_parts: list[str] = []
+            if ipv4:
+                label_parts.append(f"IPv4: {ipv4}")
+            if ipv6:
+                label_parts.append(f"IPv6: {ipv6}")
+            label_parts.append(f"MAC:  {node_id}")
+            if vendor_str:
+                label_parts.append(f"Vendor: {vendor_str}")
+            if extra:
+                label_parts.append(extra)
             if os_str:
-                label_parts.append(os_str)
-            title = f"<b>{ip}</b><br>MAC: {mac}"
+                label_parts.append(f"OS: {os_str}")
+            title = f"<b>{ipv4 or ipv6 or node_id}</b>"
+            if ipv4 and ipv6:
+                title += f"<br>IPv6: {ipv6}"
+            title += f"<br>MAC: {node_id}"
+            if vendor_str:
+                title += f"<br>Vendor: {vendor_str}"
             if os_str:
                 title += f"<br>OS: {os_str}"
-            return {"id": ip, "label": "\n".join(label_parts), "title": title, "group": group}
+            return {"id": node_id, "label": "\n".join(label_parts), "title": title, "group": group}
 
-        hub = gateway or local_ip
+        hub_id = gw_mac or local_id
 
-        if gateway:
-            nodes.append(_node(gateway, "gateway", "gateway"))
+        if gateway and gw_mac:
+            gw_dev = next((d for d in self._devices if d["mac"] == gw_mac), None)
+            nodes.append(_node(gw_mac, gw_dev["ipv4"] if gw_dev else gateway,
+                               gw_dev["ipv6"] if gw_dev else None, "gateway", "gateway"))
 
-        nodes.append(_node(local_ip, "local", "this machine"))
-        if gateway and local_ip != gateway:
-            edges.append({"from": gateway, "to": local_ip})
+        nodes.append(_node(local_id, local_ipv4, local_ipv6, "local", "this machine"))
+        if gw_mac and local_id != gw_mac:
+            edges.append({"from": gw_mac, "to": local_id})
 
-        for host in sorted(self._hosts, key=lambda h: h.ip):
-            if host.ip in (gateway, local_ip):
+        for d in sorted(self._devices, key=lambda x: (x["ipv4"] or x["ipv6"] or "")):
+            mac = d["mac"]
+            if mac in (gw_mac, local_id):
                 continue
-            nodes.append(_node(host.ip, "host"))
-            edges.append({"from": hub, "to": host.ip})
+            nodes.append(_node(mac, d["ipv4"], d["ipv6"], "host"))
+            edges.append({"from": hub_id, "to": mac})
 
         return nodes, edges
 
     def run(self) -> str:
-        local_ip = get_ip_address()
-        gateway = _get_gateway()
-        subnet = get_subnet()
+        iface      = get_network_interface()
+        local_ipv4 = get_ip_address()
+        local_ipv6 = get_ipv6_link_local(iface)
+        local_mac  = _get_local_mac(iface)
+        gateway    = _get_gateway()
+        subnet     = get_subnet()
 
         print("Constructing network graph...")
-        self._hosts = self._arp_scan()
+        arp = self._arp_scan()
+        ndp = self._ndp_scan()
+        self._devices = self._merge(arp, ndp)
+        self._vendor_map = {
+            d["mac"]: v
+            for d in self._devices
+            if (v := get_mac_vendor(d["mac"]))
+        }
 
-        if self._fingerprint and self._hosts:
-            self._fingerprint_hosts([h.ip for h in self._hosts])
+        if self._fingerprint and self._devices:
+            self._fingerprint_hosts(self._devices)
 
         scan_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
         if self._output.endswith(".json"):
-            topology = self._build_topology(gateway, local_ip, subnet, scan_time)
+            topology = self._build_topology(gateway, local_ipv4, local_ipv6, local_mac, subnet, scan_time)
             with open(self._output, "w", encoding="utf-8") as f:
                 json.dump(topology, f, indent=2)
             print(f"Network topology saved in {os.path.abspath(self._output)}")
         else:
-            nodes, edges = self._build_graph(gateway, local_ip)
+            nodes, edges = self._build_graph(gateway, local_ipv4, local_ipv6, local_mac)
             host_count = len(nodes)
             html = (
                 _HTML_TEMPLATE

--- a/sondare/services/icmp.py
+++ b/sondare/services/icmp.py
@@ -2,33 +2,76 @@
 # -*- coding: UTF-8 -*-
 
 import ipaddress
-from scapy.all import IP, ICMP, sr
+from scapy.all import IP, ICMP, IPv6, ICMPv6EchoRequest, ICMPv6EchoReply, sr, sr1
 from sondare.utils.network import get_subnet, resolve_hostnames
 
 
-class Ping:
-    """Discovers live hosts on the local network via ICMP echo."""
+def _is_ipv6(addr: str) -> bool:
+    try:
+        return isinstance(ipaddress.ip_address(addr), ipaddress.IPv6Address)
+    except ValueError:
+        return False
 
-    def __init__(self, verbose: bool, timeout: float, resolve_hostname: bool = False) -> None:
+
+class Ping:
+    """Discovers live hosts via ICMP echo.
+
+    Without a target: sends ICMPv4 to every host on the local IPv4 subnet.
+    With an IPv4 target: probes that single host with ICMPv4.
+    With an IPv6 target: probes that single host with ICMPv6 echo request.
+    """
+
+    def __init__(
+        self,
+        verbose: bool,
+        timeout: float,
+        resolve_hostname: bool = False,
+        target: str | None = None,
+    ) -> None:
         self.verbose = verbose
         self._timeout = timeout
         self._resolve_hostname = resolve_hostname
+        self._target = target
+        self._ipv6_mode = target is not None and _is_ipv6(target)
 
-        self.hosts = [str(ip) for ip in ipaddress.IPv4Network(get_subnet()).hosts()]
+        if target is None:
+            self.hosts = [str(ip) for ip in ipaddress.IPv4Network(get_subnet()).hosts()]
+        else:
+            self.hosts = [target]
+
         self.results: list[str] = []
         self._hostnames: dict[str, str | None] = {}
 
     def scan(self) -> None:
-        """Sends all ICMP echo requests in one batch and collects replies."""
-        print(f"Scanning {len(self.hosts)} hosts ...", end=" ", flush=True)
+        """Sends ICMP echo request(s) and records responding hosts."""
+        if self._ipv6_mode:
+            self._scan_icmpv6()
+        else:
+            self._scan_icmpv4()
+        if self._resolve_hostname:
+            self._hostnames = resolve_hostnames(self.results)
+
+    def _scan_icmpv4(self) -> None:
+        print(f"Scanning {len(self.hosts)} host{'s' if len(self.hosts) != 1 else ''} ...", end=" ", flush=True)
         packets = [IP(dst=h) / ICMP() for h in self.hosts]
         answered, _ = sr(packets, timeout=self._timeout, verbose=self.verbose, promisc=False, inter=0)
         print("done")
         for sent, received in answered:
             if received.haslayer(ICMP) and received.getlayer(ICMP).type == 0:
                 self.results.append(sent[IP].dst)
-        if self._resolve_hostname:
-            self._hostnames = resolve_hostnames(self.results)
+
+    def _scan_icmpv6(self) -> None:
+        target = self._target  # guaranteed non-None in this branch
+        print(f"Pinging {target} ...", end=" ", flush=True)
+        rsp = sr1(
+            IPv6(dst=target) / ICMPv6EchoRequest(id=0x5afe, seq=1),
+            timeout=self._timeout,
+            verbose=self.verbose,
+            promisc=False,
+        )
+        print("done")
+        if rsp is not None and rsp.haslayer(ICMPv6EchoReply):
+            self.results.append(target)
 
     def get_results(self) -> list[str]:
         """Returns IPs of live hosts discovered by scan()."""

--- a/sondare/services/icmp.py
+++ b/sondare/services/icmp.py
@@ -2,8 +2,11 @@
 # -*- coding: UTF-8 -*-
 
 import ipaddress
-from scapy.all import IP, ICMP, IPv6, ICMPv6EchoRequest, ICMPv6EchoReply, sr, sr1
-from sondare.utils.network import get_subnet, resolve_hostnames
+from scapy.all import IP, ICMP, IPv6, ICMPv6EchoRequest, ICMPv6EchoReply, Ether, sr, sr1, srp
+from sondare.utils.network import get_subnet, get_network_interface, get_ipv6_link_local, resolve_hostnames
+
+_ALL_NODES_MAC  = "33:33:00:00:00:01"
+_ALL_NODES_ADDR = "ff02::1"
 
 
 def _is_ipv6(addr: str) -> bool:
@@ -16,9 +19,10 @@ def _is_ipv6(addr: str) -> bool:
 class Ping:
     """Discovers live hosts via ICMP echo.
 
-    Without a target: sends ICMPv4 to every host on the local IPv4 subnet.
-    With an IPv4 target: probes that single host with ICMPv4.
-    With an IPv6 target: probes that single host with ICMPv6 echo request.
+    No flags:              ICMPv4 sweep of the local IPv4 subnet.
+    --target <ipv4>:       probe a single IPv4 host.
+    --target <ipv6>:       probe a single IPv6 host via ICMPv6.
+    --ipv6:                ICMPv6 multicast sweep of ff02::1 (all IPv6 hosts on the link).
     """
 
     def __init__(
@@ -27,17 +31,23 @@ class Ping:
         timeout: float,
         resolve_hostname: bool = False,
         target: str | None = None,
+        ipv6: bool = False,
     ) -> None:
         self.verbose = verbose
         self._timeout = timeout
         self._resolve_hostname = resolve_hostname
         self._target = target
-        self._ipv6_mode = target is not None and _is_ipv6(target)
+        self._ipv6_mode = ipv6 or (target is not None and _is_ipv6(target))
+        self._multicast = ipv6 and target is None
 
-        if target is None:
-            self.hosts = [str(ip) for ip in ipaddress.IPv4Network(get_subnet()).hosts()]
+        if not self._ipv6_mode:
+            # IPv4: enumerate the full subnet or just the single target
+            self.hosts = (
+                [target] if target is not None
+                else [str(ip) for ip in ipaddress.IPv4Network(get_subnet()).hosts()]
+            )
         else:
-            self.hosts = [target]
+            self.hosts = [] if self._multicast else [target]  # type: ignore[list-item]
 
         self.results: list[str] = []
         self._hostnames: dict[str, str | None] = {}
@@ -52,15 +62,24 @@ class Ping:
             self._hostnames = resolve_hostnames(self.results)
 
     def _scan_icmpv4(self) -> None:
-        print(f"Scanning {len(self.hosts)} host{'s' if len(self.hosts) != 1 else ''} ...", end=" ", flush=True)
+        subnet_scan = self._target is None
+        if subnet_scan:
+            print(f"Scanning {len(self.hosts)} hosts ...", end=" ", flush=True)
         packets = [IP(dst=h) / ICMP() for h in self.hosts]
         answered, _ = sr(packets, timeout=self._timeout, verbose=self.verbose, promisc=False, inter=0)
-        print("done")
+        if subnet_scan:
+            print("done")
         for sent, received in answered:
             if received.haslayer(ICMP) and received.getlayer(ICMP).type == 0:
                 self.results.append(sent[IP].dst)
 
     def _scan_icmpv6(self) -> None:
+        if self._multicast:
+            self._scan_icmpv6_multicast()
+        else:
+            self._scan_icmpv6_unicast()
+
+    def _scan_icmpv6_unicast(self) -> None:
         target = self._target  # guaranteed non-None in this branch
         print(f"Pinging {target} ...", end=" ", flush=True)
         rsp = sr1(
@@ -72,6 +91,26 @@ class Ping:
         print("done")
         if rsp is not None and rsp.haslayer(ICMPv6EchoReply):
             self.results.append(target)
+
+    def _scan_icmpv6_multicast(self) -> None:
+        iface    = get_network_interface()
+        local_ip = (get_ipv6_link_local(iface) or "").lower()
+        pkt = (
+            Ether(dst=_ALL_NODES_MAC) /
+            IPv6(dst=_ALL_NODES_ADDR) /
+            ICMPv6EchoRequest(id=0x5afe, seq=1)
+        )
+        print(f"Scanning {_ALL_NODES_ADDR} on {iface} ...", end=" ", flush=True)
+        ans, _ = srp(pkt, iface=iface, timeout=self._timeout, verbose=self.verbose, promisc=False, multi=True)
+        print("done")
+        seen: set[str] = set()
+        for _, rcv in ans:
+            if not rcv.haslayer(ICMPv6EchoReply):
+                continue
+            ip = rcv[IPv6].src.split("%")[0].lower()
+            if ip != local_ip and not ip.startswith("ff") and ip not in seen:
+                seen.add(ip)
+                self.results.append(ip)
 
     def get_results(self) -> list[str]:
         """Returns IPs of live hosts discovered by scan()."""

--- a/sondare/services/icmp.py
+++ b/sondare/services/icmp.py
@@ -3,17 +3,10 @@
 
 import ipaddress
 from scapy.all import IP, ICMP, IPv6, ICMPv6EchoRequest, ICMPv6EchoReply, Ether, sr, sr1, srp
-from sondare.utils.network import get_subnet, get_network_interface, get_ipv6_link_local, resolve_hostnames
+from sondare.utils.network import get_subnet, get_network_interface, get_ipv6_link_local, is_ipv6_address, resolve_hostnames
 
 _ALL_NODES_MAC  = "33:33:00:00:00:01"
 _ALL_NODES_ADDR = "ff02::1"
-
-
-def _is_ipv6(addr: str) -> bool:
-    try:
-        return isinstance(ipaddress.ip_address(addr), ipaddress.IPv6Address)
-    except ValueError:
-        return False
 
 
 class Ping:
@@ -37,7 +30,7 @@ class Ping:
         self._timeout = timeout
         self._resolve_hostname = resolve_hostname
         self._target = target
-        self._ipv6_mode = ipv6 or (target is not None and _is_ipv6(target))
+        self._ipv6_mode = ipv6 or (target is not None and is_ipv6_address(target))
         self._multicast = ipv6 and target is None
 
         if not self._ipv6_mode:

--- a/sondare/services/ndp.py
+++ b/sondare/services/ndp.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from scapy.all import Ether, IPv6, ICMPv6EchoRequest, ICMPv6EchoReply, srp
+from sondare.models import Host
+from sondare.utils.network import (
+    get_network_interface, get_mac_vendor, get_ipv6_link_local,
+    read_ndp_cache, resolve_hostnames,
+)
+
+# Ethernet and IPv6 all-nodes multicast addresses (RFC 4291 §2.7.1).
+_ALL_NODES_MAC  = "33:33:00:00:00:01"
+_ALL_NODES_ADDR = "ff02::1"
+
+
+class Ndp:
+    """Discovers IPv6 hosts on the local link via ICMPv6 multicast ping + NDP neighbor cache."""
+
+    def __init__(self, verbose: bool, timeout: int, resolve_hostname: bool = False) -> None:
+        self.verbose = verbose
+        self.timeout = timeout
+        self.resolve_hostname = resolve_hostname
+        self._results: list[Host] = []
+
+    def scan(self) -> None:
+        """Sends an ICMPv6 echo request to ff02::1, merges with the NDP neighbor cache,
+        and stores the final host list. Active replies take precedence over cache entries.
+        The scanner's own link-local address and multicast prefixes are excluded.
+        """
+        iface    = get_network_interface()
+        local_ip = (get_ipv6_link_local(iface) or "").lower()
+
+        pkt = (
+            Ether(dst=_ALL_NODES_MAC) /
+            IPv6(dst=_ALL_NODES_ADDR) /
+            ICMPv6EchoRequest(id=0x5afe, seq=1)
+        )
+        print(f"Scanning {_ALL_NODES_ADDR} on {iface} ...", end=" ", flush=True)
+        answer = srp(
+            pkt,
+            iface=iface,
+            timeout=self.timeout,
+            verbose=self.verbose,
+            promisc=False,
+            multi=True,
+        )[0]
+        print("done")
+
+        hosts: dict[str, str] = {}  # normalized_ipv6 -> mac
+
+        for _, rcv in answer:
+            if not rcv.haslayer(ICMPv6EchoReply):
+                continue
+            ip  = rcv[IPv6].src.split("%")[0].lower()
+            mac = rcv[Ether].src.lower()
+            if ip != local_ip and not ip.startswith("ff"):
+                hosts[ip] = mac
+
+        for ip, mac in read_ndp_cache(iface).items():
+            if ip not in hosts and ip != local_ip and not ip.startswith("ff"):
+                hosts[ip] = mac
+
+        if self.resolve_hostname:
+            names = resolve_hostnames(list(hosts))
+            self._results = [
+                Host(ip=ip, mac=mac, hostname=names.get(ip), vendor=get_mac_vendor(mac))
+                for ip, mac in sorted(hosts.items())
+            ]
+        else:
+            self._results = [
+                Host(ip=ip, mac=mac, vendor=get_mac_vendor(mac))
+                for ip, mac in sorted(hosts.items())
+            ]
+
+    def get_results(self) -> list[Host]:
+        return self._results

--- a/sondare/services/tcp.py
+++ b/sondare/services/tcp.py
@@ -5,10 +5,10 @@ import random
 import threading
 import time
 from queue import Queue
-from scapy.all import IP, TCP, sr1, sr
+from scapy.all import IP, IPv6, TCP, sr1, sr
 from sondare.models import Port
 from sondare.utils.banners import grab_banner
-from sondare.utils.network import warm_arp_cache, get_port_service
+from sondare.utils.network import warm_arp_cache, get_port_service, is_ipv6_address
 from sondare.utils.adaptive_pool import AdaptivePool
 
 
@@ -25,6 +25,7 @@ class Tcp:
         self.banners = banners
         self._timeout = timeout
 
+        self._ipv6 = is_ipv6_address(ip)
         self._pool = AdaptivePool(max_threads=threads, timeout=timeout, adapt_concurrency=True)
         self._lock = threading.Lock()
         self.q: Queue[int] = Queue()
@@ -35,13 +36,14 @@ class Tcp:
 
     def check_port(self, target_port: int) -> None:
         """Probes a port up to retries+1 times; records it if any attempt gets a SYN-ACK."""
+        ip_layer = IPv6(dst=self.ip) if self._ipv6 else IP(dst=self.ip)
         for _ in range(self.retries + 1):
             source_port = random.randint(1025, 65534)
             self._pool.acquire()
             try:
                 start = time.monotonic()
                 rsp = sr1(
-                    IP(dst=self.ip) / TCP(sport=source_port, dport=target_port, flags="S"),
+                    ip_layer / TCP(sport=source_port, dport=target_port, flags="S"),
                     timeout=self._pool.timeout,
                     verbose=self.verbose,
                     promisc=False,
@@ -57,7 +59,7 @@ class Tcp:
 
             if rsp.haslayer(TCP):
                 if rsp.getlayer(TCP).flags == 0x12:  # SYN-ACK: open
-                    sr(IP(dst=self.ip) / TCP(sport=source_port, dport=target_port, flags="R"), timeout=1, verbose=False, promisc=False)
+                    sr(ip_layer / TCP(sport=source_port, dport=target_port, flags="R"), timeout=1, verbose=False, promisc=False)
                     with self._lock:
                         self.open_ports.append(Port(ip=self.ip, port=target_port))
                 return  # RST or anything else: definitive answer, stop retrying
@@ -75,7 +77,8 @@ class Tcp:
 
     def scan(self) -> None:
         """Runs the threaded SYN scan."""
-        warm_arp_cache(self.ip)
+        if not self._ipv6:
+            warm_arp_cache(self.ip)
         thread_count = min(self.threads, self._total)
         for _ in range(thread_count):
             t = threading.Thread(target=self._threader)

--- a/sondare/services/trace.py
+++ b/sondare/services/trace.py
@@ -4,8 +4,9 @@
 import signal
 import time
 from collections.abc import Callable
-from scapy.all import IP, ICMP, sr1
+from scapy.all import IP, IPv6, ICMP, ICMPv6EchoRequest, sr1
 from sondare.models import Hop
+from sondare.utils.network import is_ipv6_address
 
 
 class Traceroute:
@@ -24,11 +25,15 @@ class Traceroute:
         self._timeout = timeout
         self._max_hops = max_hops
         self._on_hop = on_hop
+        self._ipv6 = is_ipv6_address(ip)
         self._results: list[Hop] = []
         self._interrupted = False
 
     def _probe(self, ttl: int) -> Hop:
-        pkt = IP(dst=self.ip, ttl=ttl) / ICMP()
+        if self._ipv6:
+            pkt = IPv6(dst=self.ip, hlim=ttl) / ICMPv6EchoRequest()
+        else:
+            pkt = IP(dst=self.ip, ttl=ttl) / ICMP()
         t0 = time.perf_counter()
         reply = sr1(pkt, timeout=self._timeout, verbose=self.verbose, promisc=False)
         rtt = round((time.perf_counter() - t0) * 1000, 2)

--- a/sondare/services/udp.py
+++ b/sondare/services/udp.py
@@ -4,9 +4,9 @@
 import threading
 import time
 from queue import Queue
-from scapy.all import IP, UDP, ICMP, sr1
+from scapy.all import IP, IPv6, UDP, ICMP, ICMPv6DestUnreach, sr1
 from sondare.models import Port
-from sondare.utils.network import warm_arp_cache, get_port_service
+from sondare.utils.network import warm_arp_cache, get_port_service, is_ipv6_address
 from sondare.utils.adaptive_pool import AdaptivePool
 
 
@@ -21,6 +21,7 @@ class Udp:
         self.port_end = port_end
         self.retries = retries
 
+        self._ipv6 = is_ipv6_address(ip)
         self._pool = AdaptivePool(max_threads=threads, timeout=timeout)
         self._lock = threading.Lock()
         self.q: Queue[int] = Queue()
@@ -31,12 +32,13 @@ class Udp:
 
     def check_port(self, target_port: int) -> None:
         """Probes a UDP port; records it unless ICMP port-unreachable is received."""
+        ip_layer = IPv6(dst=self.ip) if self._ipv6 else IP(dst=self.ip)
         for attempt in range(self.retries + 1):
             self._pool.acquire()
             try:
                 start = time.monotonic()
                 rsp = sr1(
-                    IP(dst=self.ip) / UDP(dport=target_port),
+                    ip_layer / UDP(dport=target_port),
                     timeout=self._pool.timeout,
                     verbose=self.verbose,
                     promisc=False,
@@ -53,10 +55,15 @@ class Udp:
                         self.open_ports.append(Port(ip=self.ip, port=target_port))
                 continue
 
-            if rsp.haslayer(ICMP):
-                icmp = rsp.getlayer(ICMP)
-                if icmp.type == 3 and icmp.code == 3:
-                    return  # port unreachable — closed
+            if self._ipv6:
+                # ICMPv6 Destination Unreachable, code 4 = port unreachable
+                if rsp.haslayer(ICMPv6DestUnreach) and rsp.getlayer(ICMPv6DestUnreach).code == 4:
+                    return
+            else:
+                if rsp.haslayer(ICMP):
+                    icmp = rsp.getlayer(ICMP)
+                    if icmp.type == 3 and icmp.code == 3:
+                        return  # port unreachable — closed
 
             with self._lock:
                 self.open_ports.append(Port(ip=self.ip, port=target_port))
@@ -75,7 +82,8 @@ class Udp:
 
     def scan(self) -> None:
         """Runs the threaded UDP scan."""
-        warm_arp_cache(self.ip)
+        if not self._ipv6:
+            warm_arp_cache(self.ip)
         thread_count = min(self.threads, self._total)
         for _ in range(thread_count):
             t = threading.Thread(target=self._threader)

--- a/sondare/utils/network.py
+++ b/sondare/utils/network.py
@@ -287,6 +287,47 @@ def read_arp_cache(subnet: str) -> dict[str, str]:
     return result
 
 
+def get_ipv6_link_local(iface: str) -> str | None:
+    """Returns the link-local IPv6 address of the given interface (without scope suffix), or None."""
+    for addr in psutil.net_if_addrs().get(iface, []):
+        if addr.family == socket.AF_INET6:
+            raw = addr.address.split("%")[0]
+            if raw.lower().startswith("fe80"):
+                return raw.lower()
+    return None
+
+
+def read_ndp_cache(iface: str) -> dict[str, str]:
+    """Returns {ipv6: mac} from the OS NDP neighbor cache for the given interface."""
+    result: dict[str, str] = {}
+    try:
+        if platform.system() == "Darwin":
+            out = subprocess.check_output(["ndp", "-an"], text=True, stderr=subprocess.DEVNULL)
+            for line in out.splitlines():
+                parts = line.split()
+                if len(parts) < 3 or parts[2] != iface:
+                    continue
+                ip_raw = parts[0].split("%")[0].lower()
+                mac = parts[1]
+                if re.match(r"(?:[0-9a-f]{1,2}:){5}[0-9a-f]{1,2}", mac, re.I):
+                    result[ip_raw] = mac.lower()
+        else:
+            out = subprocess.check_output(
+                ["ip", "-6", "neigh", "show", "dev", iface],
+                text=True, stderr=subprocess.DEVNULL,
+            )
+            for line in out.splitlines():
+                parts = line.split()
+                if "lladdr" not in parts:
+                    continue
+                ip_raw = parts[0].split("%")[0].lower()
+                mac = parts[parts.index("lladdr") + 1]
+                result[ip_raw] = mac.lower()
+    except Exception:
+        pass
+    return result
+
+
 def warm_arp_cache(ip: str) -> None:
     """ARP-resolves ip and stores the result in Scapy's cache to avoid promiscuous mode errors."""
     from scapy.all import ARP, Ether, srp, conf

--- a/sondare/utils/network.py
+++ b/sondare/utils/network.py
@@ -184,6 +184,14 @@ def _netbios_name(ip: str, timeout: float = 1.0) -> str | None:
         sock.close()
 
 
+def is_ipv6_address(addr: str) -> bool:
+    """Returns True if addr is a valid IPv6 address, False otherwise."""
+    try:
+        return isinstance(ipaddress.ip_address(addr), ipaddress.IPv6Address)
+    except ValueError:
+        return False
+
+
 def get_port_service(port: int, proto: str = "tcp") -> str | None:
     """Returns the well-known service name for a port/protocol, or None."""
     try:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,7 +1,12 @@
 import json
 from unittest.mock import patch, MagicMock
 from sondare.services.graph import NetworkGraph, _get_gateway
-from sondare.models import Host
+
+_LOCAL_MAC = "ff:ee:dd:cc:bb:aa"
+_LOCAL_IPV4 = "192.168.1.10"
+_LOCAL_IPV6 = None
+_GATEWAY_IP = "192.168.1.1"
+_VIS_STUB = "/* vis-network stub */"
 
 
 def _grapher(**kwargs) -> NetworkGraph:
@@ -10,22 +15,30 @@ def _grapher(**kwargs) -> NetworkGraph:
     return NetworkGraph(**{**defaults, **kwargs})
 
 
-def _hosts():
+def _devices():
+    """Three discovered devices: gateway, local machine, one regular host."""
     return [
-        Host(ip="192.168.1.1", mac="aa:bb:cc:dd:ee:01"),
-        Host(ip="192.168.1.10", mac="aa:bb:cc:dd:ee:02"),
-        Host(ip="192.168.1.20", mac="aa:bb:cc:dd:ee:03"),
+        {"mac": "aa:bb:cc:dd:ee:01", "ipv4": "192.168.1.1",  "ipv6": None},
+        {"mac": "aa:bb:cc:dd:ee:02", "ipv4": "192.168.1.10", "ipv6": None},
+        {"mac": "aa:bb:cc:dd:ee:03", "ipv4": "192.168.1.20", "ipv6": None},
     ]
 
 
+def _arp_map():
+    return {d["mac"]: d["ipv4"] for d in _devices()}
+
+
 def _patch_ipconfig(output: str | None):
-    """Patches subprocess so _get_gateway() reads a fake ipconfig getoption response."""
     import subprocess as sp
     if output is None:
         return patch("sondare.services.graph.subprocess.check_output",
                      side_effect=sp.CalledProcessError(1, "ipconfig"))
     return patch("sondare.services.graph.subprocess.check_output", return_value=output)
 
+
+# ---------------------------------------------------------------------------
+# _get_gateway
+# ---------------------------------------------------------------------------
 
 class TestGetGateway:
     def test_returns_gateway_ip_via_ipconfig(self):
@@ -62,235 +75,385 @@ class TestGetGateway:
             assert _get_gateway() is None
 
 
-class TestBuildGraph:
-    def test_gateway_node_has_gateway_group(self):
+# ---------------------------------------------------------------------------
+# _merge
+# ---------------------------------------------------------------------------
+
+class TestMerge:
+    def test_ipv4_only_device(self):
         g = _grapher()
-        g._hosts = _hosts()
-        nodes, _ = g._build_graph(gateway="192.168.1.1", local_ip="192.168.1.10")
-        gw = next(n for n in nodes if n["id"] == "192.168.1.1")
+        result = g._merge({"aa:bb:cc:dd:ee:01": "10.0.0.1"}, {})
+        assert result == [{"mac": "aa:bb:cc:dd:ee:01", "ipv4": "10.0.0.1", "ipv6": None}]
+
+    def test_ipv6_only_device(self):
+        g = _grapher()
+        result = g._merge({}, {"aa:bb:cc:dd:ee:01": "fe80::1"})
+        assert result == [{"mac": "aa:bb:cc:dd:ee:01", "ipv4": None, "ipv6": "fe80::1"}]
+
+    def test_dual_stack_device_merged_into_one(self):
+        g = _grapher()
+        arp = {"aa:bb:cc:dd:ee:01": "10.0.0.1"}
+        ndp = {"aa:bb:cc:dd:ee:01": "fe80::1"}
+        result = g._merge(arp, ndp)
+        assert len(result) == 1
+        assert result[0]["ipv4"] == "10.0.0.1"
+        assert result[0]["ipv6"] == "fe80::1"
+
+    def test_distinct_macs_produce_distinct_devices(self):
+        g = _grapher()
+        arp = {"aa:bb:cc:dd:ee:01": "10.0.0.1", "aa:bb:cc:dd:ee:02": "10.0.0.2"}
+        result = g._merge(arp, {})
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# _build_graph
+# ---------------------------------------------------------------------------
+
+class TestBuildGraph:
+    def _graph(self):
+        g = _grapher()
+        g._devices = _devices()
+        return g
+
+    def _build(self, g, gateway=_GATEWAY_IP, local_ipv4=_LOCAL_IPV4,
+               local_ipv6=None, local_mac=_LOCAL_MAC):
+        return g._build_graph(gateway=gateway, local_ipv4=local_ipv4,
+                               local_ipv6=local_ipv6, local_mac=local_mac)
+
+    def test_gateway_node_has_gateway_group(self):
+        g = self._graph()
+        nodes, _ = self._build(g)
+        gw = next(n for n in nodes if n["id"] == "aa:bb:cc:dd:ee:01")
         assert gw["group"] == "gateway"
 
     def test_local_node_has_local_group(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        nodes, _ = g._build_graph(gateway="192.168.1.1", local_ip="192.168.1.10")
-        local = next(n for n in nodes if n["id"] == "192.168.1.10")
+        g = self._graph()
+        nodes, _ = self._build(g)
+        local = next(n for n in nodes if n["id"] == _LOCAL_MAC)
         assert local["group"] == "local"
 
     def test_regular_host_has_host_group(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        nodes, _ = g._build_graph(gateway="192.168.1.1", local_ip="192.168.1.10")
-        host = next(n for n in nodes if n["id"] == "192.168.1.20")
+        g = self._graph()
+        nodes, _ = self._build(g)
+        host = next(n for n in nodes if n["id"] == "aa:bb:cc:dd:ee:03")
         assert host["group"] == "host"
 
     def test_edges_connect_hosts_to_gateway(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        _, edges = g._build_graph(gateway="192.168.1.1", local_ip="192.168.1.10")
-        edge_targets = {e["to"] for e in edges}
-        assert "192.168.1.20" in edge_targets
+        g = self._graph()
+        _, edges = self._build(g)
+        assert any(e["to"] == "aa:bb:cc:dd:ee:03" for e in edges)
 
     def test_all_edges_originate_from_gateway(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        _, edges = g._build_graph(gateway="192.168.1.1", local_ip="192.168.1.10")
-        assert all(e["from"] == "192.168.1.1" for e in edges)
+        g = self._graph()
+        _, edges = self._build(g)
+        assert all(e["from"] == "aa:bb:cc:dd:ee:01" for e in edges)
 
     def test_no_gateway_edges_originate_from_local(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        _, edges = g._build_graph(gateway=None, local_ip="192.168.1.10")
-        assert all(e["from"] == "192.168.1.10" for e in edges)
+        g = self._graph()
+        _, edges = self._build(g, gateway=None)
+        assert all(e["from"] == _LOCAL_MAC for e in edges)
 
     def test_os_in_node_title_when_fingerprinted(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        g._os_map["192.168.1.20"] = "Linux / Unix"
-        nodes, _ = g._build_graph(gateway="192.168.1.1", local_ip="192.168.1.10")
-        host = next(n for n in nodes if n["id"] == "192.168.1.20")
+        g = self._graph()
+        g._os_map["aa:bb:cc:dd:ee:03"] = "Linux / Unix"
+        nodes, _ = self._build(g)
+        host = next(n for n in nodes if n["id"] == "aa:bb:cc:dd:ee:03")
         assert "Linux / Unix" in host["title"]
 
     def test_os_in_node_label_when_fingerprinted(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        g._os_map["192.168.1.20"] = "Linux / Unix"
-        nodes, _ = g._build_graph(gateway="192.168.1.1", local_ip="192.168.1.10")
-        host = next(n for n in nodes if n["id"] == "192.168.1.20")
-        assert "Linux / Unix" in host["label"]
+        g = self._graph()
+        g._os_map["aa:bb:cc:dd:ee:03"] = "Linux / Unix"
+        nodes, _ = self._build(g)
+        host = next(n for n in nodes if n["id"] == "aa:bb:cc:dd:ee:03")
+        assert "OS: Linux / Unix" in host["label"]
 
-    def test_local_ip_not_duplicated_when_in_arp_results(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        nodes, _ = g._build_graph(gateway="192.168.1.1", local_ip="192.168.1.10")
+    def test_vendor_in_node_label(self):
+        g = self._graph()
+        g._vendor_map["aa:bb:cc:dd:ee:03"] = "Apple, Inc."
+        nodes, _ = self._build(g)
+        host = next(n for n in nodes if n["id"] == "aa:bb:cc:dd:ee:03")
+        assert "Vendor: Apple, Inc." in host["label"]
+
+    def test_vendor_in_node_title(self):
+        g = self._graph()
+        g._vendor_map["aa:bb:cc:dd:ee:03"] = "Apple, Inc."
+        nodes, _ = self._build(g)
+        host = next(n for n in nodes if n["id"] == "aa:bb:cc:dd:ee:03")
+        assert "Vendor: Apple, Inc." in host["title"]
+
+    def test_no_vendor_line_when_unknown(self):
+        g = self._graph()
+        nodes, _ = self._build(g)
+        host = next(n for n in nodes if n["id"] == "aa:bb:cc:dd:ee:03")
+        assert "Vendor:" not in host["label"]
+
+    def test_local_not_duplicated(self):
+        g = self._graph()
+        nodes, _ = self._build(g)
         ids = [n["id"] for n in nodes]
-        assert ids.count("192.168.1.10") == 1
+        assert ids.count(_LOCAL_MAC) == 1
 
-    def test_gateway_not_duplicated_as_regular_host(self):
+    def test_gateway_not_duplicated(self):
+        g = self._graph()
+        nodes, _ = self._build(g)
+        gw_nodes = [n for n in nodes if n["id"] == "aa:bb:cc:dd:ee:01"]
+        assert len(gw_nodes) == 1
+
+    def test_dual_stack_device_single_node_with_both_ips(self):
         g = _grapher()
-        g._hosts = _hosts()
-        nodes, _ = g._build_graph(gateway="192.168.1.1", local_ip="192.168.1.10")
-        gateway_nodes = [n for n in nodes if n["id"] == "192.168.1.1"]
-        assert len(gateway_nodes) == 1
+        g._devices = [{"mac": "aa:bb:cc:dd:ee:03", "ipv4": "192.168.1.20", "ipv6": "fe80::3"}]
+        nodes, _ = self._build(g, gateway=None)
+        host = next(n for n in nodes if n["id"] == "aa:bb:cc:dd:ee:03")
+        assert "IPv4: 192.168.1.20" in host["label"]
+        assert "IPv6: fe80::3" in host["label"]
+
+    def test_ipv6_only_device_appears_as_node(self):
+        g = _grapher()
+        g._devices = [{"mac": "bb:cc:dd:ee:ff:01", "ipv4": None, "ipv6": "fe80::cafe"}]
+        nodes, _ = self._build(g, gateway=None)
+        assert any(n["id"] == "bb:cc:dd:ee:ff:01" for n in nodes)
+
+    def test_local_mac_fallback_to_ip_when_none(self):
+        g = _grapher()
+        g._devices = []
+        nodes, _ = g._build_graph(gateway=None, local_ipv4="10.0.0.1",
+                                   local_ipv6=None, local_mac=None)
+        assert any(n["id"] == "10.0.0.1" for n in nodes)
 
 
-_VIS_STUB = "/* vis-network stub */"
-_HTML_PATCHES = (
-    patch("sondare.services.graph._load_vis_network", return_value=_VIS_STUB),
-)
+# ---------------------------------------------------------------------------
+# _build_topology
+# ---------------------------------------------------------------------------
+
+class TestBuildTopology:
+    def _topo(self, g, gateway=_GATEWAY_IP, local_ipv4=_LOCAL_IPV4,
+              local_ipv6=None, local_mac=_LOCAL_MAC):
+        return g._build_topology(gateway, local_ipv4, local_ipv6, local_mac,
+                                  "192.168.1.0/24", "2026-06-01 12:00:00")
+
+    def test_structure_keys(self):
+        g = _grapher()
+        g._devices = _devices()
+        topo = self._topo(g)
+        assert set(topo.keys()) == {"subnet", "gateway", "local_ipv4", "scan_time", "hosts"}
+
+    def test_gateway_role(self):
+        g = _grapher()
+        g._devices = _devices()
+        topo = self._topo(g)
+        gw = next(h for h in topo["hosts"] if h.get("ipv4") == _GATEWAY_IP)
+        assert gw["role"] == "gateway"
+
+    def test_local_role(self):
+        g = _grapher()
+        g._devices = _devices()
+        topo = self._topo(g)
+        local = next(h for h in topo["hosts"] if h.get("ipv4") == _LOCAL_IPV4)
+        assert local["role"] == "local"
+
+    def test_regular_host_role(self):
+        g = _grapher()
+        g._devices = _devices()
+        topo = self._topo(g)
+        host = next(h for h in topo["hosts"] if h.get("ipv4") == "192.168.1.20")
+        assert host["role"] == "host"
+
+    def test_os_included_when_fingerprinted(self):
+        g = _grapher()
+        g._devices = _devices()
+        g._os_map["aa:bb:cc:dd:ee:03"] = "Linux / Unix"
+        topo = self._topo(g)
+        host = next(h for h in topo["hosts"] if h.get("ipv4") == "192.168.1.20")
+        assert host["os"] == "Linux / Unix"
+
+    def test_os_omitted_when_not_fingerprinted(self):
+        g = _grapher()
+        g._devices = _devices()
+        topo = self._topo(g)
+        host = next(h for h in topo["hosts"] if h.get("ipv4") == "192.168.1.20")
+        assert "os" not in host
+
+    def test_no_gateway_sets_none(self):
+        g = _grapher()
+        g._devices = _devices()
+        topo = self._topo(g, gateway=None)
+        assert topo["gateway"] is None
+
+    def test_local_machine_present_when_not_in_scan_results(self):
+        g = _grapher()
+        g._devices = []
+        topo = self._topo(g)
+        assert any(h.get("ipv4") == _LOCAL_IPV4 for h in topo["hosts"])
+
+    def test_dual_stack_device_has_both_address_fields(self):
+        g = _grapher()
+        g._devices = [{"mac": "aa:bb:cc:dd:ee:03", "ipv4": "192.168.1.20", "ipv6": "fe80::3"}]
+        topo = self._topo(g, gateway=None)
+        host = next(h for h in topo["hosts"] if h.get("ipv4") == "192.168.1.20")
+        assert host["ipv6"] == "fe80::3"
+
+    def test_ipv4_only_device_has_no_ipv6_field(self):
+        g = _grapher()
+        g._devices = [{"mac": "aa:bb:cc:dd:ee:03", "ipv4": "192.168.1.20", "ipv6": None}]
+        topo = self._topo(g, gateway=None)
+        host = next(h for h in topo["hosts"] if h.get("ipv4") == "192.168.1.20")
+        assert "ipv6" not in host
+
+    def test_vendor_included_in_topology(self):
+        g = _grapher()
+        g._devices = _devices()
+        g._vendor_map["aa:bb:cc:dd:ee:03"] = "Apple, Inc."
+        topo = self._topo(g)
+        host = next(h for h in topo["hosts"] if h.get("ipv4") == "192.168.1.20")
+        assert host["vendor"] == "Apple, Inc."
+
+    def test_vendor_omitted_when_unknown(self):
+        g = _grapher()
+        g._devices = _devices()
+        topo = self._topo(g)
+        host = next(h for h in topo["hosts"] if h.get("ipv4") == "192.168.1.20")
+        assert "vendor" not in host
 
 
-def _html_run(g, tmp_path_or_out):
-    """Runs g.run() with all network and vis-network calls patched."""
-    out = tmp_path_or_out if isinstance(tmp_path_or_out, str) else str(tmp_path_or_out / "graph.html")
-    with patch.object(g, "_arp_scan", return_value=_hosts()), \
-         patch("sondare.services.graph._get_gateway", return_value="192.168.1.1"), \
-         patch("sondare.services.graph.get_ip_address", return_value="192.168.1.10"), \
-         patch("sondare.services.graph.get_subnet", return_value="192.168.1.0/24"), \
-         patch("sondare.services.graph._load_vis_network", return_value=_VIS_STUB):
-        return g.run(), out
+# ---------------------------------------------------------------------------
+# run() — HTML
+# ---------------------------------------------------------------------------
+
+def _run_patches(g, arp=None, ndp=None):
+    """Context manager that patches all I/O for g.run()."""
+    from contextlib import ExitStack
+    stack = ExitStack()
+    stack.enter_context(patch.object(g, "_arp_scan", return_value=arp or _arp_map()))
+    stack.enter_context(patch.object(g, "_ndp_scan", return_value=ndp or {}))
+    stack.enter_context(patch("sondare.services.graph._get_gateway", return_value=_GATEWAY_IP))
+    stack.enter_context(patch("sondare.services.graph.get_ip_address", return_value=_LOCAL_IPV4))
+    stack.enter_context(patch("sondare.services.graph.get_network_interface", return_value="en0"))
+    stack.enter_context(patch("sondare.services.graph.get_ipv6_link_local", return_value=None))
+    stack.enter_context(patch("sondare.services.graph._get_local_mac", return_value=_LOCAL_MAC))
+    stack.enter_context(patch("sondare.services.graph.get_subnet", return_value="192.168.1.0/24"))
+    stack.enter_context(patch("sondare.services.graph._load_vis_network", return_value=_VIS_STUB))
+    return stack
 
 
 class TestRun:
     def test_writes_html_file(self, tmp_path):
         out = str(tmp_path / "graph.html")
         g = _grapher(output=out)
-        _html_run(g, out)
+        with _run_patches(g):
+            g.run()
         assert open(out).read().startswith("<!DOCTYPE html>")
 
     def test_html_contains_node_data(self, tmp_path):
         out = str(tmp_path / "graph.html")
         g = _grapher(output=out)
-        _html_run(g, out)
+        with _run_patches(g):
+            g.run()
         assert "192.168.1.20" in open(out).read()
 
     def test_returns_output_path(self, tmp_path):
         out = str(tmp_path / "graph.html")
         g = _grapher(output=out)
-        result, _ = _html_run(g, out)
+        with _run_patches(g):
+            result = g.run()
         assert result == out
 
     def test_fingerprint_called_when_enabled(self, tmp_path):
         out = str(tmp_path / "graph.html")
         g = _grapher(output=out, fingerprint=True)
-        with patch.object(g, "_arp_scan", return_value=_hosts()), \
-             patch.object(g, "_fingerprint_hosts") as mock_fp, \
-             patch("sondare.services.graph._get_gateway", return_value="192.168.1.1"), \
-             patch("sondare.services.graph.get_ip_address", return_value="192.168.1.10"), \
-             patch("sondare.services.graph.get_subnet", return_value="192.168.1.0/24"), \
-             patch("sondare.services.graph._load_vis_network", return_value=_VIS_STUB):
+        with _run_patches(g), patch.object(g, "_fingerprint_hosts") as mock_fp:
             g.run()
         mock_fp.assert_called_once()
 
     def test_fingerprint_not_called_when_disabled(self, tmp_path):
         out = str(tmp_path / "graph.html")
         g = _grapher(output=out, fingerprint=False)
-        with patch.object(g, "_arp_scan", return_value=_hosts()), \
-             patch.object(g, "_fingerprint_hosts") as mock_fp, \
-             patch("sondare.services.graph._get_gateway", return_value="192.168.1.1"), \
-             patch("sondare.services.graph.get_ip_address", return_value="192.168.1.10"), \
-             patch("sondare.services.graph.get_subnet", return_value="192.168.1.0/24"), \
-             patch("sondare.services.graph._load_vis_network", return_value=_VIS_STUB):
+        with _run_patches(g), patch.object(g, "_fingerprint_hosts") as mock_fp:
             g.run()
         mock_fp.assert_not_called()
 
     def test_vis_network_inlined_no_cdn(self, tmp_path):
         out = str(tmp_path / "graph.html")
         g = _grapher(output=out)
-        _html_run(g, out)
+        with _run_patches(g):
+            g.run()
         content = open(out).read()
         assert "unpkg.com" not in content
         assert _VIS_STUB in content
 
+    def test_vendor_lookup_called_for_each_device(self, tmp_path):
+        out = str(tmp_path / "graph.html")
+        g = _grapher(output=out)
+        with _run_patches(g), \
+             patch("sondare.services.graph.get_mac_vendor", return_value="Raspberry Pi") as mock_v:
+            g.run()
+        assert mock_v.call_count == len(_arp_map())
 
-class TestBuildTopology:
-    def test_structure_keys(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        topo = g._build_topology(gateway="192.168.1.1", local_ip="192.168.1.10",
-                                  subnet="192.168.1.0/24", scan_time="2026-06-01 12:00:00")
-        assert set(topo.keys()) == {"subnet", "gateway", "local_ip", "scan_time", "hosts"}
+    def test_ndp_scan_called_during_run(self, tmp_path):
+        out = str(tmp_path / "graph.html")
+        g = _grapher(output=out)
+        with _run_patches(g), patch.object(g, "_ndp_scan", return_value={}) as mock_ndp:
+            g.run()
+        mock_ndp.assert_called_once()
 
-    def test_gateway_role(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        topo = g._build_topology("192.168.1.1", "192.168.1.10", "192.168.1.0/24", "t")
-        gw = next(h for h in topo["hosts"] if h["ip"] == "192.168.1.1")
-        assert gw["role"] == "gateway"
+    def test_dual_stack_device_is_single_node(self, tmp_path):
+        out = str(tmp_path / "graph.html")
+        g = _grapher(output=out)
+        shared_mac = "aa:bb:cc:dd:ee:05"
+        arp = {shared_mac: "192.168.1.50"}
+        ndp = {shared_mac: "fe80::5"}
+        with _run_patches(g, arp=arp, ndp=ndp):
+            g.run()
+        content = open(out).read()
+        # Both addresses present and only one node id for that MAC
+        assert shared_mac in content
+        assert content.count(shared_mac) >= 1  # appears as node id
+        assert "192.168.1.50" in content
+        assert "fe80::5" in content
 
-    def test_local_role(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        topo = g._build_topology("192.168.1.1", "192.168.1.10", "192.168.1.0/24", "t")
-        local = next(h for h in topo["hosts"] if h["ip"] == "192.168.1.10")
-        assert local["role"] == "local"
 
-    def test_regular_host_role(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        topo = g._build_topology("192.168.1.1", "192.168.1.10", "192.168.1.0/24", "t")
-        host = next(h for h in topo["hosts"] if h["ip"] == "192.168.1.20")
-        assert host["role"] == "host"
-
-    def test_os_included_when_fingerprinted(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        g._os_map["192.168.1.20"] = "Linux / Unix"
-        topo = g._build_topology("192.168.1.1", "192.168.1.10", "192.168.1.0/24", "t")
-        host = next(h for h in topo["hosts"] if h["ip"] == "192.168.1.20")
-        assert host["os"] == "Linux / Unix"
-
-    def test_os_omitted_when_not_fingerprinted(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        topo = g._build_topology("192.168.1.1", "192.168.1.10", "192.168.1.0/24", "t")
-        host = next(h for h in topo["hosts"] if h["ip"] == "192.168.1.20")
-        assert "os" not in host
-
-    def test_no_gateway_sets_none(self):
-        g = _grapher()
-        g._hosts = _hosts()
-        topo = g._build_topology(None, "192.168.1.10", "192.168.1.0/24", "t")
-        assert topo["gateway"] is None
-
-    def test_local_ip_always_present(self):
-        g = _grapher()
-        g._hosts = []  # empty ARP results
-        topo = g._build_topology(None, "192.168.1.10", "192.168.1.0/24", "t")
-        assert any(h["ip"] == "192.168.1.10" for h in topo["hosts"])
-
+# ---------------------------------------------------------------------------
+# run() — JSON
+# ---------------------------------------------------------------------------
 
 class TestRunJson:
-    def _run_json(self, tmp_path, fingerprint=False):
+    def _run_json(self, tmp_path, fingerprint=False, ndp=None):
         out = str(tmp_path / "graph.json")
         g = _grapher(output=out, fingerprint=fingerprint)
-        with patch.object(g, "_arp_scan", return_value=_hosts()), \
-             patch("sondare.services.graph._get_gateway", return_value="192.168.1.1"), \
-             patch("sondare.services.graph.get_ip_address", return_value="192.168.1.10"), \
-             patch("sondare.services.graph.get_subnet", return_value="192.168.1.0/24"):
+        with _run_patches(g, ndp=ndp or {}):
             g.run()
         return json.loads(open(out).read())
 
     def test_writes_valid_json(self, tmp_path):
-        data = self._run_json(tmp_path)
-        assert isinstance(data, dict)
+        assert isinstance(self._run_json(tmp_path), dict)
 
     def test_json_contains_subnet(self, tmp_path):
         data = self._run_json(tmp_path)
         assert data["subnet"] == "192.168.1.0/24"
 
-    def test_json_contains_all_hosts(self, tmp_path):
+    def test_json_contains_all_discovered_hosts(self, tmp_path):
         data = self._run_json(tmp_path)
-        ips = {h["ip"] for h in data["hosts"]}
-        assert "192.168.1.1" in ips
-        assert "192.168.1.20" in ips
+        ipv4s = {h.get("ipv4") for h in data["hosts"]}
+        assert "192.168.1.1" in ipv4s
+        assert "192.168.1.20" in ipv4s
 
     def test_html_not_written_for_json_output(self, tmp_path):
         out = str(tmp_path / "graph.json")
         g = _grapher(output=out)
-        with patch.object(g, "_arp_scan", return_value=_hosts()), \
-             patch("sondare.services.graph._get_gateway", return_value="192.168.1.1"), \
-             patch("sondare.services.graph.get_ip_address", return_value="192.168.1.10"), \
-             patch("sondare.services.graph.get_subnet", return_value="192.168.1.0/24"):
+        with _run_patches(g):
             g.run()
         assert not open(out).read().startswith("<!DOCTYPE html>")
+
+    def test_json_dual_stack_host_has_both_fields(self, tmp_path):
+        shared_mac = "aa:bb:cc:dd:ee:05"
+        data = self._run_json(tmp_path, ndp={shared_mac: "fe80::5"},
+                              )
+        # shared_mac appears only in ndp (no ipv4), so it should have ipv6 but no ipv4
+        host = next((h for h in data["hosts"] if h.get("ipv6") == "fe80::5"), None)
+        assert host is not None
+        assert "ipv4" not in host
+
+    def test_json_local_ipv4_key_present(self, tmp_path):
+        data = self._run_json(tmp_path)
+        assert "local_ipv4" in data
+        assert data["local_ipv4"] == _LOCAL_IPV4

--- a/tests/test_icmp.py
+++ b/tests/test_icmp.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch, MagicMock
 from scapy.all import IP, ICMP
-from sondare.services.icmp import Ping
+from sondare.services.icmp import Ping, _is_ipv6
 
 
 def _make_ping_scanner(net_mocks, ip="192.168.1.1"):
@@ -59,6 +59,87 @@ class TestGetResults:
     def test_returns_empty_before_scan(self, net_mocks):
         scanner = _make_ping_scanner(net_mocks)
         assert scanner.get_results() == []
+
+
+class TestIsIpv6:
+    def test_ipv6_link_local(self):
+        assert _is_ipv6("fe80::1") is True
+
+    def test_ipv6_full(self):
+        assert _is_ipv6("2001:db8::1") is True
+
+    def test_ipv4(self):
+        assert _is_ipv6("192.168.1.1") is False
+
+    def test_invalid(self):
+        assert _is_ipv6("not-an-ip") is False
+
+
+class TestIpv6Ping:
+    def _make_v6_reply(self, has_reply: bool = True):
+        pkt = MagicMock()
+        pkt.haslayer.side_effect = lambda cls: has_reply and cls.__name__ == "ICMPv6EchoReply"
+        return pkt
+
+    def test_ipv6_target_sends_icmpv6(self):
+        with patch("sondare.services.icmp.sr1", return_value=None) as mock_sr1, \
+             patch("builtins.print"):
+            scanner = Ping(verbose=False, timeout=1, target="fe80::1")
+            scanner.scan()
+
+        from scapy.all import IPv6, ICMPv6EchoRequest
+        mock_sr1.assert_called_once()
+        pkt = mock_sr1.call_args[0][0]
+        assert pkt.haslayer(IPv6)
+        assert pkt.haslayer(ICMPv6EchoRequest)
+
+    def test_ipv6_echo_reply_adds_host(self):
+        target = "fe80::dead:beef"
+        with patch("sondare.services.icmp.sr1", return_value=self._make_v6_reply(True)), \
+             patch("builtins.print"):
+            scanner = Ping(verbose=False, timeout=1, target=target)
+            scanner.scan()
+
+        assert scanner.get_results() == [target]
+
+    def test_ipv6_no_reply_empty_results(self):
+        with patch("sondare.services.icmp.sr1", return_value=None), \
+             patch("builtins.print"):
+            scanner = Ping(verbose=False, timeout=1, target="fe80::1")
+            scanner.scan()
+
+        assert scanner.get_results() == []
+
+    def test_ipv6_non_echo_reply_ignored(self):
+        with patch("sondare.services.icmp.sr1", return_value=self._make_v6_reply(False)), \
+             patch("builtins.print"):
+            scanner = Ping(verbose=False, timeout=1, target="fe80::1")
+            scanner.scan()
+
+        assert scanner.get_results() == []
+
+    def test_ipv6_does_not_call_sr(self):
+        with patch("sondare.services.icmp.sr1", return_value=None), \
+             patch("sondare.services.icmp.sr") as mock_sr, \
+             patch("builtins.print"):
+            scanner = Ping(verbose=False, timeout=1, target="fe80::1")
+            scanner.scan()
+
+        mock_sr.assert_not_called()
+
+    def test_ipv4_target_uses_icmpv4_not_sr1(self, net_mocks):
+        addrs, stats = net_mocks(ip="192.168.1.1")
+        with patch("psutil.net_if_addrs", return_value=addrs), \
+             patch("psutil.net_if_stats", return_value=stats):
+            scanner = Ping(verbose=False, timeout=1, target="192.168.1.2")
+
+        with patch("sondare.services.icmp.sr", return_value=([], [])) as mock_sr, \
+             patch("sondare.services.icmp.sr1") as mock_sr1, \
+             patch("builtins.print"):
+            scanner.scan()
+
+        mock_sr.assert_called_once()
+        mock_sr1.assert_not_called()
 
 
 class TestResolveHostname:

--- a/tests/test_icmp.py
+++ b/tests/test_icmp.py
@@ -141,6 +141,94 @@ class TestIpv6Ping:
         mock_sr.assert_called_once()
         mock_sr1.assert_not_called()
 
+    def test_ipv4_target_only_scans_that_host(self, net_mocks):
+        addrs, stats = net_mocks(ip="192.168.1.1")
+        with patch("psutil.net_if_addrs", return_value=addrs), \
+             patch("psutil.net_if_stats", return_value=stats):
+            scanner = Ping(verbose=False, timeout=1, target="192.168.1.2")
+
+        assert scanner.hosts == ["192.168.1.2"]
+
+
+def _v6_multicast_reply(src_ip: str, is_reply: bool = True):
+    ipv6_layer = MagicMock()
+    ipv6_layer.src = src_ip
+    pkt = MagicMock()
+    pkt.haslayer.side_effect = lambda cls: is_reply and cls.__name__ == "ICMPv6EchoReply"
+    pkt.__getitem__ = MagicMock(side_effect=lambda cls: ipv6_layer if cls.__name__ == "IPv6" else MagicMock())
+    return pkt
+
+
+class TestIpv6MulticastScan:
+    def _scan(self, scanner, srp_pairs=None, local_ip="fe80::1"):
+        with patch("sondare.services.icmp.get_network_interface", return_value="eth0"), \
+             patch("sondare.services.icmp.get_ipv6_link_local", return_value=local_ip), \
+             patch("sondare.services.icmp.srp", return_value=(srp_pairs or [], None)), \
+             patch("builtins.print"):
+            scanner.scan()
+
+    def test_ipv6_flag_triggers_multicast_scan(self):
+        with patch("sondare.services.icmp.get_network_interface", return_value="eth0"), \
+             patch("sondare.services.icmp.get_ipv6_link_local", return_value="fe80::1"), \
+             patch("sondare.services.icmp.srp", return_value=([], None)) as mock_srp, \
+             patch("builtins.print"):
+            Ping(verbose=False, timeout=3, ipv6=True).scan()
+
+        kwargs = mock_srp.call_args.kwargs
+        assert kwargs["multi"] is True
+        assert kwargs["iface"] == "eth0"
+
+    def test_multicast_collects_echo_replies(self):
+        pairs = [
+            (None, _v6_multicast_reply("fe80::aaaa")),
+            (None, _v6_multicast_reply("fe80::bbbb")),
+        ]
+        scanner = Ping(verbose=False, timeout=1, ipv6=True)
+        self._scan(scanner, srp_pairs=pairs)
+
+        assert set(scanner.get_results()) == {"fe80::aaaa", "fe80::bbbb"}
+
+    def test_multicast_excludes_own_link_local(self):
+        own = "fe80::dead:beef"
+        pairs = [(None, _v6_multicast_reply(own))]
+        scanner = Ping(verbose=False, timeout=1, ipv6=True)
+        self._scan(scanner, srp_pairs=pairs, local_ip=own)
+
+        assert scanner.get_results() == []
+
+    def test_multicast_ignores_non_echo_reply(self):
+        pairs = [(None, _v6_multicast_reply("fe80::1234", is_reply=False))]
+        scanner = Ping(verbose=False, timeout=1, ipv6=True)
+        self._scan(scanner, srp_pairs=pairs)
+
+        assert scanner.get_results() == []
+
+    def test_multicast_deduplicates_replies(self):
+        pairs = [
+            (None, _v6_multicast_reply("fe80::cafe")),
+            (None, _v6_multicast_reply("fe80::cafe")),
+        ]
+        scanner = Ping(verbose=False, timeout=1, ipv6=True)
+        self._scan(scanner, srp_pairs=pairs)
+
+        assert scanner.get_results() == ["fe80::cafe"]
+
+    def test_ipv6_flag_does_not_call_sr_or_sr1(self):
+        with patch("sondare.services.icmp.get_network_interface", return_value="eth0"), \
+             patch("sondare.services.icmp.get_ipv6_link_local", return_value="fe80::1"), \
+             patch("sondare.services.icmp.srp", return_value=([], None)), \
+             patch("sondare.services.icmp.sr") as mock_sr, \
+             patch("sondare.services.icmp.sr1") as mock_sr1, \
+             patch("builtins.print"):
+            Ping(verbose=False, timeout=1, ipv6=True).scan()
+
+        mock_sr.assert_not_called()
+        mock_sr1.assert_not_called()
+
+    def test_ipv6_flag_hosts_list_is_empty(self):
+        scanner = Ping(verbose=False, timeout=1, ipv6=True)
+        assert scanner.hosts == []
+
 
 class TestResolveHostname:
     def test_get_hostnames_empty_without_flag(self, net_mocks):

--- a/tests/test_icmp.py
+++ b/tests/test_icmp.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, MagicMock
 from scapy.all import IP, ICMP
-from sondare.services.icmp import Ping, _is_ipv6
+from sondare.services.icmp import Ping
+from sondare.utils.network import is_ipv6_address as _is_ipv6
 
 
 def _make_ping_scanner(net_mocks, ip="192.168.1.1"):

--- a/tests/test_main_output.py
+++ b/tests/test_main_output.py
@@ -6,7 +6,7 @@ from sondare.main import main
 
 
 def _args(**kwargs):
-    defaults = dict(scan_method=None, verbose=False, timeout=1, json=False)
+    defaults = dict(scan_method=None, verbose=False, timeout=1, json=False, target=None)
     defaults.update(kwargs)
     m = MagicMock()
     for k, v in defaults.items():

--- a/tests/test_ndp.py
+++ b/tests/test_ndp.py
@@ -1,0 +1,164 @@
+from unittest.mock import patch, MagicMock, call
+from sondare.services.ndp import Ndp
+from sondare.models import Host
+
+
+def _echo_reply(src_ip: str, src_mac: str, is_reply: bool = True):
+    """Builds a mock packet that looks like an ICMPv6 Echo Reply."""
+    ipv6_layer = MagicMock()
+    ipv6_layer.src = src_ip
+    ether_layer = MagicMock()
+    ether_layer.src = src_mac
+
+    pkt = MagicMock()
+    pkt.haslayer.side_effect = lambda cls: is_reply and cls.__name__ == "ICMPv6EchoReply"
+    pkt.__getitem__ = MagicMock(
+        side_effect=lambda cls: ipv6_layer if cls.__name__ == "IPv6" else ether_layer
+    )
+    return pkt
+
+
+def _scan(scanner, srp_pairs=None, ndp_cache=None, local_ip="fe80::1"):
+    """Helper: runs scanner.scan() with all network calls mocked."""
+    with patch("sondare.services.ndp.get_network_interface", return_value="eth0"), \
+         patch("sondare.services.ndp.get_ipv6_link_local", return_value=local_ip), \
+         patch("sondare.services.ndp.srp", return_value=(srp_pairs or [], None)), \
+         patch("sondare.services.ndp.read_ndp_cache", return_value=ndp_cache or {}), \
+         patch("sondare.services.ndp.get_mac_vendor", return_value=None), \
+         patch("builtins.print"):
+        scanner.scan()
+
+
+class TestNdpScan:
+    def test_get_results_before_scan_returns_empty(self):
+        scanner = Ndp(verbose=False, timeout=1)
+        assert scanner.get_results() == []
+
+    def test_scan_calls_srp_with_multicast_and_multi_flag(self):
+        with patch("sondare.services.ndp.get_network_interface", return_value="eth0"), \
+             patch("sondare.services.ndp.get_ipv6_link_local", return_value="fe80::1"), \
+             patch("sondare.services.ndp.srp", return_value=([], None)) as mock_srp, \
+             patch("sondare.services.ndp.read_ndp_cache", return_value={}), \
+             patch("builtins.print"):
+            Ndp(verbose=False, timeout=3).scan()
+
+        kwargs = mock_srp.call_args.kwargs
+        assert kwargs["iface"] == "eth0"
+        assert kwargs["timeout"] == 3
+        assert kwargs["multi"] is True
+        assert kwargs["verbose"] is False
+        assert kwargs["promisc"] is False
+
+    def test_returns_host_for_each_echo_reply(self):
+        pairs = [
+            (None, _echo_reply("fe80::aaaa", "aa:bb:cc:dd:ee:01")),
+            (None, _echo_reply("fe80::bbbb", "aa:bb:cc:dd:ee:02")),
+        ]
+        scanner = Ndp(verbose=False, timeout=1)
+        _scan(scanner, srp_pairs=pairs)
+
+        results = scanner.get_results()
+        assert len(results) == 2
+        ips = {h.ip for h in results}
+        assert "fe80::aaaa" in ips
+        assert "fe80::bbbb" in ips
+
+    def test_non_echo_reply_packets_are_ignored(self):
+        pairs = [
+            (None, _echo_reply("fe80::aaaa", "aa:bb:cc:dd:ee:01", is_reply=False)),
+        ]
+        scanner = Ndp(verbose=False, timeout=1)
+        _scan(scanner, srp_pairs=pairs)
+        assert scanner.get_results() == []
+
+    def test_excludes_own_link_local_address(self):
+        own = "fe80::dead:beef"
+        pairs = [(None, _echo_reply(own, "aa:bb:cc:dd:ee:ff"))]
+        scanner = Ndp(verbose=False, timeout=1)
+        _scan(scanner, srp_pairs=pairs, local_ip=own)
+        assert scanner.get_results() == []
+
+    def test_excludes_multicast_addresses_from_cache(self):
+        cache = {
+            "ff02::1": "33:33:00:00:00:01",
+            "fe80::1111": "aa:bb:cc:dd:ee:ff",
+        }
+        scanner = Ndp(verbose=False, timeout=1)
+        _scan(scanner, ndp_cache=cache)
+
+        results = scanner.get_results()
+        assert len(results) == 1
+        assert results[0].ip == "fe80::1111"
+
+    def test_merges_neighbor_cache_when_active_scan_empty(self):
+        cache = {"fe80::cafe": "de:ad:be:ef:00:01"}
+        scanner = Ndp(verbose=False, timeout=1)
+        _scan(scanner, ndp_cache=cache)
+
+        results = scanner.get_results()
+        assert results == [Host(ip="fe80::cafe", mac="de:ad:be:ef:00:01")]
+
+    def test_active_scan_entry_not_duplicated_by_cache(self):
+        pairs = [(None, _echo_reply("fe80::cafe", "aa:bb:cc:dd:ee:01"))]
+        cache = {"fe80::cafe": "11:22:33:44:55:66"}  # same IP, different MAC
+        scanner = Ndp(verbose=False, timeout=1)
+        _scan(scanner, srp_pairs=pairs, ndp_cache=cache)
+
+        results = scanner.get_results()
+        assert len(results) == 1
+        assert results[0].mac == "aa:bb:cc:dd:ee:01"  # active scan MAC wins
+
+    def test_results_are_sorted_by_ip(self):
+        pairs = [
+            (None, _echo_reply("fe80::cccc", "cc:cc:cc:cc:cc:cc")),
+            (None, _echo_reply("fe80::aaaa", "aa:aa:aa:aa:aa:aa")),
+            (None, _echo_reply("fe80::bbbb", "bb:bb:bb:bb:bb:bb")),
+        ]
+        scanner = Ndp(verbose=False, timeout=1)
+        _scan(scanner, srp_pairs=pairs)
+
+        ips = [h.ip for h in scanner.get_results()]
+        assert ips == sorted(ips)
+
+    def test_resolve_hostname_populates_field(self):
+        pairs = [(None, _echo_reply("fe80::1234", "aa:bb:cc:dd:ee:01"))]
+        scanner = Ndp(verbose=False, timeout=1, resolve_hostname=True)
+
+        with patch("sondare.services.ndp.get_network_interface", return_value="eth0"), \
+             patch("sondare.services.ndp.get_ipv6_link_local", return_value="fe80::1"), \
+             patch("sondare.services.ndp.srp", return_value=(pairs, None)), \
+             patch("sondare.services.ndp.read_ndp_cache", return_value={}), \
+             patch("sondare.services.ndp.get_mac_vendor", return_value=None), \
+             patch("sondare.services.ndp.resolve_hostnames",
+                   return_value={"fe80::1234": "myhost.local"}) as mock_resolve, \
+             patch("builtins.print"):
+            scanner.scan()
+            results = scanner.get_results()
+
+        assert results[0].hostname == "myhost.local"
+        mock_resolve.assert_called_once_with(["fe80::1234"])
+
+    def test_vendor_looked_up_for_each_host(self):
+        pairs = [(None, _echo_reply("fe80::1234", "aa:bb:cc:dd:ee:01"))]
+        scanner = Ndp(verbose=False, timeout=1)
+
+        with patch("sondare.services.ndp.get_network_interface", return_value="eth0"), \
+             patch("sondare.services.ndp.get_ipv6_link_local", return_value="fe80::1"), \
+             patch("sondare.services.ndp.srp", return_value=(pairs, None)), \
+             patch("sondare.services.ndp.read_ndp_cache", return_value={}), \
+             patch("sondare.services.ndp.get_mac_vendor", return_value="Apple, Inc.") as mock_vendor, \
+             patch("builtins.print"):
+            scanner.scan()
+            results = scanner.get_results()
+
+        assert results[0].vendor == "Apple, Inc."
+        mock_vendor.assert_called_once_with("aa:bb:cc:dd:ee:01")
+
+    def test_scope_suffix_stripped_from_ip(self):
+        # Some stacks return addresses with %iface scope suffix.
+        pairs = [(None, _echo_reply("fe80::abcd%eth0", "aa:bb:cc:dd:ee:01"))]
+        scanner = Ndp(verbose=False, timeout=1)
+        _scan(scanner, srp_pairs=pairs)
+
+        results = scanner.get_results()
+        assert results[0].ip == "fe80::abcd"

--- a/tests/test_ndp_watcher.py
+++ b/tests/test_ndp_watcher.py
@@ -1,0 +1,144 @@
+from unittest.mock import patch, MagicMock, call
+from sondare.monitors.ndp_watcher import NdpWatcher
+
+
+def _na_pkt(src_ip: str, src_mac: str, has_na: bool = True):
+    """Mock ICMPv6 Neighbor Advertisement packet."""
+    ipv6_layer = MagicMock()
+    ipv6_layer.src = src_ip
+    ether_layer = MagicMock()
+    ether_layer.src = src_mac
+
+    pkt = MagicMock()
+    pkt.haslayer.side_effect = lambda cls: {
+        "IPv6": True,
+        "ICMPv6ND_NA": has_na,
+        "Ether": True,
+    }.get(cls.__name__, False)
+    pkt.__getitem__ = MagicMock(
+        side_effect=lambda cls: ipv6_layer if cls.__name__ == "IPv6" else ether_layer
+    )
+    return pkt
+
+
+def _echo_reply(src_ip: str, src_mac: str):
+    ipv6_layer = MagicMock()
+    ipv6_layer.src = src_ip
+    ether_layer = MagicMock()
+    ether_layer.src = src_mac
+    pkt = MagicMock()
+    pkt.haslayer.side_effect = lambda cls: cls.__name__ == "ICMPv6EchoReply"
+    pkt.__getitem__ = MagicMock(
+        side_effect=lambda cls: ipv6_layer if cls.__name__ == "IPv6" else ether_layer
+    )
+    return pkt
+
+
+def _make_watcher(local_ip="fe80::1"):
+    with patch("sondare.monitors.ndp_watcher.get_network_interface", return_value="eth0"), \
+         patch("sondare.monitors.ndp_watcher.get_ipv6_link_local", return_value=local_ip):
+        return NdpWatcher(verbose=False, timeout=3)
+
+
+def _seed(watcher, srp_pairs=None, ndp_cache=None):
+    with patch("sondare.monitors.ndp_watcher.srp", return_value=(srp_pairs or [], None)), \
+         patch("sondare.monitors.ndp_watcher.read_ndp_cache", return_value=ndp_cache or {}), \
+         patch("builtins.print"):
+        watcher._seed()
+
+
+class TestSeed:
+    def test_seed_calls_srp_multicast_with_multi(self):
+        watcher = _make_watcher()
+        with patch("sondare.monitors.ndp_watcher.srp", return_value=([], None)) as mock_srp, \
+             patch("sondare.monitors.ndp_watcher.read_ndp_cache", return_value={}), \
+             patch("builtins.print"):
+            watcher._seed()
+
+        kwargs = mock_srp.call_args.kwargs
+        assert kwargs["multi"] is True
+        assert kwargs["iface"] == "eth0"
+
+    def test_seed_collects_echo_replies(self):
+        watcher = _make_watcher()
+        pairs = [
+            (None, _echo_reply("fe80::aaaa", "aa:bb:cc:dd:ee:01")),
+            (None, _echo_reply("fe80::bbbb", "aa:bb:cc:dd:ee:02")),
+        ]
+        _seed(watcher, srp_pairs=pairs)
+        assert set(watcher._hosts.keys()) == {"fe80::aaaa", "fe80::bbbb"}
+
+    def test_seed_merges_ndp_cache(self):
+        watcher = _make_watcher()
+        _seed(watcher, ndp_cache={"fe80::cafe": "de:ad:be:ef:00:01"})
+        assert "fe80::cafe" in watcher._hosts
+
+    def test_seed_excludes_own_link_local(self):
+        watcher = _make_watcher(local_ip="fe80::dead:beef")
+        pairs = [(None, _echo_reply("fe80::dead:beef", "aa:bb:cc:dd:ee:ff"))]
+        _seed(watcher, srp_pairs=pairs)
+        assert watcher._hosts == {}
+
+    def test_seed_excludes_multicast_from_cache(self):
+        watcher = _make_watcher()
+        _seed(watcher, ndp_cache={"ff02::1": "33:33:00:00:00:01"})
+        assert watcher._hosts == {}
+
+    def test_seed_active_scan_takes_precedence_over_cache(self):
+        watcher = _make_watcher()
+        pairs = [(None, _echo_reply("fe80::cafe", "aa:11:22:33:44:55"))]
+        _seed(watcher, srp_pairs=pairs, ndp_cache={"fe80::cafe": "ff:ee:dd:cc:bb:aa"})
+        assert watcher._hosts["fe80::cafe"] == "aa:11:22:33:44:55"
+
+    def test_seed_strips_scope_suffix(self):
+        watcher = _make_watcher()
+        pairs = [(None, _echo_reply("fe80::abcd%eth0", "aa:bb:cc:dd:ee:01"))]
+        _seed(watcher, srp_pairs=pairs)
+        assert "fe80::abcd" in watcher._hosts
+        assert "fe80::abcd%eth0" not in watcher._hosts
+
+
+class TestHandle:
+    def test_new_host_is_printed(self, capsys):
+        watcher = _make_watcher()
+        watcher._handle(_na_pkt("fe80::1111", "aa:bb:cc:dd:ee:01"))
+        out = capsys.readouterr().out
+        assert "NEW" in out
+        assert "fe80::1111" in out
+
+    def test_changed_mac_is_printed(self, capsys):
+        watcher = _make_watcher()
+        watcher._hosts["fe80::1111"] = "aa:bb:cc:dd:ee:01"
+        watcher._handle(_na_pkt("fe80::1111", "ff:ee:dd:cc:bb:aa"))
+        out = capsys.readouterr().out
+        assert "CHANGED" in out
+        assert "NDP spoofing" in out
+
+    def test_unchanged_host_is_silent(self, capsys):
+        watcher = _make_watcher()
+        watcher._hosts["fe80::1111"] = "aa:bb:cc:dd:ee:01"
+        watcher._handle(_na_pkt("fe80::1111", "aa:bb:cc:dd:ee:01"))
+        out = capsys.readouterr().out
+        assert out == ""
+
+    def test_own_link_local_ignored(self, capsys):
+        watcher = _make_watcher(local_ip="fe80::1")
+        watcher._handle(_na_pkt("fe80::1", "aa:bb:cc:dd:ee:ff"))
+        assert capsys.readouterr().out == ""
+
+    def test_multicast_address_ignored(self, capsys):
+        watcher = _make_watcher()
+        watcher._handle(_na_pkt("ff02::1", "33:33:00:00:00:01"))
+        assert capsys.readouterr().out == ""
+
+    def test_non_na_packet_ignored(self, capsys):
+        watcher = _make_watcher()
+        watcher._handle(_na_pkt("fe80::1234", "aa:bb:cc:dd:ee:01", has_na=False))
+        assert capsys.readouterr().out == ""
+
+    def test_scope_suffix_stripped(self, capsys):
+        watcher = _make_watcher()
+        watcher._handle(_na_pkt("fe80::abcd%eth0", "aa:bb:cc:dd:ee:01"))
+        out = capsys.readouterr().out
+        assert "fe80::abcd" in out
+        assert "%" not in out

--- a/tests/test_parse_target.py
+++ b/tests/test_parse_target.py
@@ -53,3 +53,40 @@ def test_ip_only_uses_default_range():
     t = parse_target("10.0.0.1")
     assert t.port_begin == 1
     assert t.port_end == 1000
+
+
+# IPv6 tests
+def test_bare_ipv6_defaults_ports():
+    assert parse_target("fe80::1") == Target("fe80::1", 1, 1000)
+
+
+def test_bracket_ipv6_single_port():
+    assert parse_target("[fe80::1]:80") == Target("fe80::1", 80, 80)
+
+
+def test_bracket_ipv6_port_range():
+    assert parse_target("[fe80::dead:beef]:1-1024") == Target("fe80::dead:beef", 1, 1024)
+
+
+def test_bracket_ipv6_no_port_defaults():
+    assert parse_target("[2001:db8::1]") == Target("2001:db8::1", 1, 1000)
+
+
+def test_bracket_ipv6_invalid_raises():
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_target("[not closed")
+
+
+def test_bracket_ipv6_reversed_range_raises():
+    with pytest.raises(argparse.ArgumentTypeError, match="must be <="):
+        parse_target("[fe80::1]:443-80")
+
+
+def test_bare_ipv6_with_port_suggests_bracket_notation():
+    with pytest.raises(argparse.ArgumentTypeError, match="bracket notation"):
+        parse_target("fe80::c331:6970:6df:6e96:1-10")
+
+
+def test_bare_ipv6_that_is_also_valid_address_uses_default_ports():
+    # fe80::1:80 is itself a valid IPv6 address, so it's accepted as-is with default port range.
+    assert parse_target("fe80::1:80") == Target("fe80::1:80", 1, 1000)

--- a/tests/test_port_watcher.py
+++ b/tests/test_port_watcher.py
@@ -1,11 +1,11 @@
-from unittest.mock import patch
-from sondare.monitors.port_watcher import PortWatcher
+from unittest.mock import patch, MagicMock
+from sondare.monitors.port_watcher import PortWatcher, _syn_scan
 
 
-def _watcher(port_begin=1, port_end=100, interval=60) -> PortWatcher:
+def _watcher(ip="192.168.1.1", port_begin=1, port_end=100, interval=60) -> PortWatcher:
     return PortWatcher(
         verbose=False,
-        ip="192.168.1.1",
+        ip=ip,
         port_begin=port_begin,
         port_end=port_end,
         timeout=3.0,
@@ -189,3 +189,52 @@ class TestPortWatcher:
 
         out = capsys.readouterr().out
         assert "none" in out
+
+
+class TestIpv6PortWatcher:
+    def test_ipv6_target_uses_ipv6_layer(self):
+        sent_pkts = []
+
+        def fake_sr1(pkt, **_kw):
+            sent_pkts.append(pkt)
+            return None
+
+        with patch("sondare.monitors.port_watcher.sr1", side_effect=fake_sr1):
+            _syn_scan("fe80::1", 80, 80, timeout=1, threads=1, verbose=False)
+
+        from scapy.all import IPv6
+        assert any(pkt.haslayer(IPv6) for pkt in sent_pkts)
+
+    def test_ipv4_target_uses_ip_layer(self):
+        sent_pkts = []
+
+        def fake_sr1(pkt, **_kw):
+            sent_pkts.append(pkt)
+            return None
+
+        with patch("sondare.monitors.port_watcher.sr1", side_effect=fake_sr1):
+            _syn_scan("192.168.1.1", 80, 80, timeout=1, threads=1, verbose=False)
+
+        from scapy.all import IP, IPv6
+        assert all(pkt.haslayer(IP) and not pkt.haslayer(IPv6) for pkt in sent_pkts)
+
+    def test_ipv6_watch_skips_warm_arp_cache(self, capsys):
+        w = _watcher(ip="fe80::1")
+        with patch.object(w, "_scan", side_effect=KeyboardInterrupt), \
+             patch("sondare.monitors.port_watcher.warm_arp_cache") as mock_arp, \
+             patch("sondare.monitors.port_watcher.is_ipv6_address", return_value=True):
+            try:
+                w.watch()
+            except KeyboardInterrupt:
+                pass
+        mock_arp.assert_not_called()
+
+    def test_ipv4_watch_calls_warm_arp_cache(self, capsys):
+        w = _watcher(ip="192.168.1.1")
+        with patch.object(w, "_scan", side_effect=KeyboardInterrupt), \
+             patch("sondare.monitors.port_watcher.warm_arp_cache") as mock_arp:
+            try:
+                w.watch()
+            except KeyboardInterrupt:
+                pass
+        mock_arp.assert_called_once_with("192.168.1.1")

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -241,3 +241,34 @@ class TestBannersIntegration:
 
         mock_grab.assert_not_called()
         assert scanner.open_ports == [Port(ip="10.0.0.1", port=80, banner=None)]
+
+
+class TestIpv6Tcp:
+    def test_ipv6_target_uses_ipv6_layer(self):
+        from scapy.all import IPv6
+        scanner = Tcp(verbose=False, ip="fe80::1", port_begin=80, port_end=80,
+                      timeout=1, threads=1, retries=0)
+        with patch("sondare.services.tcp.sr1", return_value=None) as mock_sr1, \
+             patch("sondare.services.tcp.warm_arp_cache"):
+            scanner.check_port(80)
+
+        pkt = mock_sr1.call_args[0][0]
+        assert pkt.haslayer(IPv6)
+
+    def test_ipv6_scan_skips_arp_cache(self):
+        scanner = Tcp(verbose=False, ip="fe80::1", port_begin=80, port_end=80,
+                      timeout=1, threads=1, retries=0)
+        with patch("sondare.services.tcp.sr1", return_value=None), \
+             patch("sondare.services.tcp.warm_arp_cache") as mock_arp:
+            scanner.scan()
+
+        mock_arp.assert_not_called()
+
+    def test_ipv4_scan_calls_arp_cache(self):
+        scanner = Tcp(verbose=False, ip="192.168.1.1", port_begin=80, port_end=80,
+                      timeout=1, threads=1, retries=0)
+        with patch("sondare.services.tcp.sr1", return_value=None), \
+             patch("sondare.services.tcp.warm_arp_cache") as mock_arp:
+            scanner.scan()
+
+        mock_arp.assert_called_once_with("192.168.1.1")

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -87,3 +87,35 @@ def test_main_trace_json_output(capsys):
         except json.JSONDecodeError:
             continue
     assert False, "No JSON line found in output"
+
+
+def test_ipv6_target_uses_ipv6_layer():
+    from scapy.all import IPv6, ICMPv6EchoRequest
+    with patch("sondare.services.trace.sr1", return_value=None) as mock_sr1:
+        scanner = Traceroute(verbose=False, ip="fe80::1", timeout=1, max_hops=1)
+        scanner.scan()
+
+    pkt = mock_sr1.call_args[0][0]
+    assert pkt.haslayer(IPv6)
+    assert pkt.haslayer(ICMPv6EchoRequest)
+
+
+def test_ipv4_target_uses_ip_layer():
+    from scapy.all import IP, ICMP
+    with patch("sondare.services.trace.sr1", return_value=None) as mock_sr1:
+        scanner = Traceroute(verbose=False, ip="8.8.8.8", timeout=1, max_hops=1)
+        scanner.scan()
+
+    pkt = mock_sr1.call_args[0][0]
+    assert pkt.haslayer(IP)
+    assert pkt.haslayer(ICMP)
+
+
+def test_ipv6_hlim_set_correctly():
+    from scapy.all import IPv6
+    with patch("sondare.services.trace.sr1", return_value=None) as mock_sr1:
+        scanner = Traceroute(verbose=False, ip="fe80::1", timeout=1, max_hops=3)
+        scanner.scan()
+
+    hlim_values = [mock_sr1.call_args_list[i][0][0][IPv6].hlim for i in range(3)]
+    assert hlim_values == [1, 2, 3]

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -123,3 +123,41 @@ class TestGetResults:
 
         ports = [p.port for p in scanner.get_results()]
         assert ports == sorted(ports)
+
+
+class TestIpv6Udp:
+    def test_ipv6_target_uses_ipv6_layer(self):
+        from scapy.all import IPv6
+        scanner = Udp(verbose=False, ip="fe80::1", port_begin=53, port_end=53,
+                      timeout=1, threads=1, retries=0)
+        with patch("sondare.services.udp.sr1", return_value=None) as mock_sr1, \
+             patch("sondare.services.udp.warm_arp_cache"):
+            scanner.check_port(53)
+
+        pkt = mock_sr1.call_args[0][0]
+        assert pkt.haslayer(IPv6)
+
+    def test_ipv6_port_unreachable_closes_port(self):
+        from unittest.mock import patch, MagicMock
+        icmpv6 = MagicMock()
+        icmpv6.code = 4
+        pkt = MagicMock()
+        pkt.haslayer.side_effect = lambda cls: cls.__name__ == "ICMPv6DestUnreach"
+        pkt.getlayer.return_value = icmpv6
+
+        scanner = Udp(verbose=False, ip="fe80::1", port_begin=53, port_end=53,
+                      timeout=1, threads=1, retries=0)
+        with patch("sondare.services.udp.sr1", return_value=pkt), \
+             patch("sondare.services.udp.warm_arp_cache"):
+            scanner.check_port(53)
+
+        assert scanner.open_ports == []
+
+    def test_ipv6_scan_skips_arp_cache(self):
+        scanner = Udp(verbose=False, ip="fe80::1", port_begin=53, port_end=53,
+                      timeout=1, threads=1, retries=0)
+        with patch("sondare.services.udp.sr1", return_value=None), \
+             patch("sondare.services.udp.warm_arp_cache") as mock_arp:
+            scanner.scan()
+
+        mock_arp.assert_not_called()

--- a/tests/test_updown_monitor.py
+++ b/tests/test_updown_monitor.py
@@ -201,3 +201,61 @@ class TestUpDownMonitor:
             except KeyboardInterrupt:
                 pass
         mock_arp.assert_not_called()
+
+
+class TestIpv6HostsWatcher:
+    def _make_v6_reply(self, has_reply: bool = True):
+        pkt = MagicMock()
+        pkt.haslayer.side_effect = lambda cls: has_reply and cls.__name__ == "ICMPv6EchoReply"
+        return pkt
+
+    def test_ping_ipv6_sends_icmpv6_echo_request(self):
+        m = _monitor()
+        sent_pkts = []
+
+        def fake_sr1(pkt, **_kw):
+            sent_pkts.append(pkt)
+            return None
+
+        with patch("sondare.monitors.hosts_watcher.sr1", side_effect=fake_sr1):
+            m._ping("fe80::1")
+
+        from scapy.all import IPv6, ICMPv6EchoRequest
+        assert any(pkt.haslayer(IPv6) and pkt.haslayer(ICMPv6EchoRequest) for pkt in sent_pkts)
+
+    def test_ping_ipv6_returns_true_on_echo_reply(self):
+        m = _monitor()
+        with patch("sondare.monitors.hosts_watcher.sr1", return_value=self._make_v6_reply(True)):
+            assert m._ping("fe80::1") is True
+
+    def test_ping_ipv6_returns_false_on_no_response(self):
+        m = _monitor()
+        with patch("sondare.monitors.hosts_watcher.sr1", return_value=None):
+            assert m._ping("fe80::1") is False
+
+    def test_ping_ipv6_returns_false_on_wrong_reply(self):
+        m = _monitor()
+        with patch("sondare.monitors.hosts_watcher.sr1", return_value=self._make_v6_reply(False)):
+            assert m._ping("fe80::1") is False
+
+    def test_ping_ipv4_does_not_use_icmpv6(self):
+        m = _monitor()
+        sent_pkts = []
+
+        def fake_sr1(pkt, **_kw):
+            sent_pkts.append(pkt)
+            return None
+
+        with patch("sondare.monitors.hosts_watcher.sr1", side_effect=fake_sr1):
+            m._ping("192.168.1.1")
+
+        from scapy.all import ICMPv6EchoRequest
+        assert not any(pkt.haslayer(ICMPv6EchoRequest) for pkt in sent_pkts)
+
+    def test_draw_widens_column_for_ipv6_address(self, capsys):
+        m = _monitor(hosts=[])
+        m._state = {"fe80::dead:beef:1234:5678": (True, "12:00:00")}
+        m._draw("12:00:00")
+        out = capsys.readouterr().out
+        # The IPv6 address must appear without truncation
+        assert "fe80::dead:beef:1234:5678" in out


### PR DESCRIPTION
## Summary

This PR bring full IPv6 network stack support to sondare.

## Changes

- `ndp` scanning method as an IPv6 counterpart for `arp`
- `ping` IPv6 support via `--ipv6` option
  - `--target` option support for pinging a single address
- `tcp`, `udp`, `os` and `trace` dual stack support
- `monitor hosts` and `monitor ports` dual stack support
- `monitor ndp` monitoring method as an IPv6 counterpart for `monitor arp`
- `graph` IPv6 support by running NDP scan alongside with ARP
  - vendor info at the node  
  - labels for IPv4, IPv6, MAC, OS and Vendor

## Testing

All tests are landed into tests/ directory

## Related issues

None
