### PR TITLE
v1.1.1 - Small fixes and refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # PyCharm settings
 .idea
 
+# VSCode settings
+.vscode/
+
 # C extensions
 *.so
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sondare"
-version = "1.1.0"
+version = "1.1.1"
 description = "Probe and monitor local network hosts — ARP, NDP, ICMP, TCP, UDP, OS fingerprinting, TLS probing, and network graph."
 readme = "README.md"
 license = "MIT"

--- a/sondare/main.py
+++ b/sondare/main.py
@@ -410,11 +410,11 @@ def main() -> None:
             results = scanner.get_results()
 
             if args.json:
-                if args.resolve_hostname:
-                    hostnames = scanner.get_hostnames()
-                    print(json.dumps({"hosts": [{"ip": ip, "hostname": hostnames[ip]} for ip in results]}))
-                else:
-                    print(json.dumps({"hosts": results}))
+                hostnames = scanner.get_hostnames() if args.resolve_hostname else {}
+                print(json.dumps({"hosts": [
+                    {"ip": ip, **({"hostname": hostnames[ip]} if hostnames.get(ip) else {})}
+                    for ip in results
+                ]}))
             else:
                 hostnames = scanner.get_hostnames() if args.resolve_hostname else {}
                 for ip in results:
@@ -562,10 +562,12 @@ def main() -> None:
         elif args.scan_method == "trace":
             print(f"Tracing route to {args.target}, max {args.max_hops} hops\n")
 
+            _ip_col = 45 if network.is_ipv6_address(args.target) else 18
+
             def _fmt_hop(hop: "Hop") -> str:
                 if hop.ip is None:
                     return f"{hop.ttl:>3}  *"
-                return f"{hop.ttl:>3}  {hop.ip:<18} {hop.rtt_ms:.2f} ms"
+                return f"{hop.ttl:>3}  {hop.ip:<{_ip_col}} {hop.rtt_ms:.2f} ms"
 
             on_hop = None if args.json else lambda h: print(_fmt_hop(h))
             scanner = Traceroute(
@@ -638,9 +640,12 @@ def main() -> None:
                 if not results:
                     print("No mDNS services found.")
                 else:
-                    print("HOSTNAME".ljust(35) + "IP".ljust(18) + "SERVICE".ljust(30) + "PORT")
+                    host_col    = max((len(r.hostname) for r in results), default=8) + 2
+                    ip_col      = max((len(r.ip) for r in results), default=2) + 2
+                    service_col = max((len(r.service) for r in results), default=7) + 2
+                    print("HOSTNAME".ljust(host_col) + "IP".ljust(ip_col) + "SERVICE".ljust(service_col) + "PORT")
                     for r in results:
-                        print(f"{r.hostname.ljust(35)}{r.ip.ljust(18)}{r.service.ljust(30)}{r.port}")
+                        print(f"{r.hostname.ljust(host_col)}{r.ip.ljust(ip_col)}{r.service.ljust(service_col)}{r.port}")
 
     except KeyboardInterrupt:
         print("\nStopped.")

--- a/sondare/monitors/arp_watcher.py
+++ b/sondare/monitors/arp_watcher.py
@@ -37,9 +37,10 @@ class ArpWatcher:
             self._hosts[rcv.psrc] = rcv.hwsrc
         print(f"found {len(self._hosts)} host(s)")
         if self._hosts:
-            print("  " + "IP".ljust(16) + "MAC")
+            ip_w = max(len(ip) for ip in self._hosts) + 2
+            print("  " + "IP".ljust(ip_w) + "MAC")
             for ip, mac in sorted(self._hosts.items()):
-                print(f"  {ip.ljust(16)}{mac}")
+                print(f"  {ip.ljust(ip_w)}{mac}")
 
     def _handle(self, pkt: Packet) -> None:
         arp = pkt.getlayer(ARP)

--- a/sondare/monitors/ndp_watcher.py
+++ b/sondare/monitors/ndp_watcher.py
@@ -5,10 +5,10 @@ import threading
 from datetime import datetime
 from scapy.all import Ether, IPv6, ICMPv6EchoRequest, ICMPv6EchoReply, ICMPv6ND_NA, srp, sniff
 from scapy.packet import Packet
-from sondare.utils.network import get_network_interface, get_ipv6_link_local, read_ndp_cache
-
-_ALL_NODES_MAC  = "33:33:00:00:00:01"
-_ALL_NODES_ADDR = "ff02::1"
+from sondare.utils.network import (
+    get_network_interface, get_ipv6_link_local, read_ndp_cache,
+    IPV6_ALL_NODES_MAC, IPV6_ALL_NODES_ADDR,
+)
 
 
 class NdpWatcher:
@@ -31,8 +31,8 @@ class NdpWatcher:
     def _seed(self) -> None:
         print(f"Seeding from ICMPv6 multicast sweep on {self._iface} ...", end=" ", flush=True)
         pkt = (
-            Ether(dst=_ALL_NODES_MAC)
-            / IPv6(dst=_ALL_NODES_ADDR)
+            Ether(dst=IPV6_ALL_NODES_MAC)
+            / IPv6(dst=IPV6_ALL_NODES_ADDR)
             / ICMPv6EchoRequest(id=0x5afe, seq=1)
         )
         ans = srp(

--- a/sondare/services/arp.py
+++ b/sondare/services/arp.py
@@ -9,35 +9,31 @@ from sondare.utils.network import get_subnet, get_network_interface, get_mac_ven
 class Arp:
     """Discovers hosts on the local network via ARP broadcast."""
 
-    def __init__(self, verbose: bool, timeout: int, resolve_hostname: bool = False) -> None:
+    def __init__(self, verbose: bool, timeout: float, resolve_hostname: bool = False) -> None:
         self.verbose = verbose
         self.timeout = timeout
         self.resolve_hostname = resolve_hostname
-        self._answer = None
-        self._cidr: str = ""
+        self._results: list[Host] = []
 
     def scan(self) -> None:
-        """Sends ARP broadcast and records responses."""
-        self._cidr = get_subnet()
+        """Sends ARP broadcast, merges the OS ARP cache, resolves hostnames and vendor names."""
+        cidr = get_subnet()
         iface = get_network_interface()
-        print(f"Scanning {self._cidr} on {iface} ...", end=" ", flush=True)
-        arp = ARP(pdst=self._cidr)
-        ether = Ether(dst="ff:ff:ff:ff:ff:ff")
-        self._answer = srp(ether/arp, iface=iface, timeout=self.timeout, verbose=self.verbose, promisc=False)[0]
+        print(f"Scanning {cidr} on {iface} ...", end=" ", flush=True)
+        answer = srp(Ether(dst="ff:ff:ff:ff:ff:ff") / ARP(pdst=cidr), iface=iface, timeout=self.timeout, verbose=self.verbose, promisc=False)[0]
         print("done")
 
-    def get_results(self) -> list[Host]:
-        """Returns a Host(ip, mac[, hostname]) for each responding host."""
-        if self._answer is None:
-            return []
-        hosts = [Host(ip=rcv.psrc, mac=rcv.hwsrc) for _, rcv in self._answer]
+        hosts = [Host(ip=rcv.psrc, mac=rcv.hwsrc) for _, rcv in answer]
         seen = {h.ip for h in hosts}
-        for ip, mac in read_arp_cache(self._cidr).items():
+        for ip, mac in read_arp_cache(cidr).items():
             if ip not in seen:
                 hosts.append(Host(ip=ip, mac=mac))
+
         if self.resolve_hostname:
             names = resolve_hostnames([h.ip for h in hosts])
-            hosts = [Host(ip=h.ip, mac=h.mac, hostname=names[h.ip], vendor=get_mac_vendor(h.mac)) for h in hosts]
+            self._results = [Host(ip=h.ip, mac=h.mac, hostname=names[h.ip], vendor=get_mac_vendor(h.mac)) for h in hosts]
         else:
-            hosts = [Host(ip=h.ip, mac=h.mac, vendor=get_mac_vendor(h.mac)) for h in hosts]
-        return hosts
+            self._results = [Host(ip=h.ip, mac=h.mac, vendor=get_mac_vendor(h.mac)) for h in hosts]
+
+    def get_results(self) -> list[Host]:
+        return self._results

--- a/sondare/services/graph.py
+++ b/sondare/services/graph.py
@@ -16,10 +16,8 @@ from sondare.services.fingerprint import OsFingerprinter
 from sondare.utils.network import (
     get_subnet, get_network_interface, get_ip_address,
     get_ipv6_link_local, read_ndp_cache, get_mac_vendor,
+    IPV6_ALL_NODES_MAC, IPV6_ALL_NODES_ADDR,
 )
-
-_ALL_NODES_MAC  = "33:33:00:00:00:01"
-_ALL_NODES_ADDR = "ff02::1"
 
 _HTML_TEMPLATE = """\
 <!DOCTYPE html>
@@ -200,8 +198,8 @@ class NetworkGraph:
         iface = get_network_interface()
         local_v6 = (get_ipv6_link_local(iface) or "").lower()
         pkt = (
-            Ether(dst=_ALL_NODES_MAC)
-            / IPv6(dst=_ALL_NODES_ADDR)
+            Ether(dst=IPV6_ALL_NODES_MAC)
+            / IPv6(dst=IPV6_ALL_NODES_ADDR)
             / ICMPv6EchoRequest(id=0x5afe, seq=1)
         )
         ans = srp(

--- a/sondare/services/icmp.py
+++ b/sondare/services/icmp.py
@@ -3,10 +3,10 @@
 
 import ipaddress
 from scapy.all import IP, ICMP, IPv6, ICMPv6EchoRequest, ICMPv6EchoReply, Ether, sr, sr1, srp
-from sondare.utils.network import get_subnet, get_network_interface, get_ipv6_link_local, is_ipv6_address, resolve_hostnames
-
-_ALL_NODES_MAC  = "33:33:00:00:00:01"
-_ALL_NODES_ADDR = "ff02::1"
+from sondare.utils.network import (
+    get_subnet, get_network_interface, get_ipv6_link_local, is_ipv6_address,
+    resolve_hostnames, IPV6_ALL_NODES_MAC, IPV6_ALL_NODES_ADDR,
+)
 
 
 class Ping:
@@ -89,11 +89,11 @@ class Ping:
         iface    = get_network_interface()
         local_ip = (get_ipv6_link_local(iface) or "").lower()
         pkt = (
-            Ether(dst=_ALL_NODES_MAC) /
-            IPv6(dst=_ALL_NODES_ADDR) /
+            Ether(dst=IPV6_ALL_NODES_MAC) /
+            IPv6(dst=IPV6_ALL_NODES_ADDR) /
             ICMPv6EchoRequest(id=0x5afe, seq=1)
         )
-        print(f"Scanning {_ALL_NODES_ADDR} on {iface} ...", end=" ", flush=True)
+        print(f"Scanning {IPV6_ALL_NODES_ADDR} on {iface} ...", end=" ", flush=True)
         ans, _ = srp(pkt, iface=iface, timeout=self._timeout, verbose=self.verbose, promisc=False, multi=True)
         print("done")
         seen: set[str] = set()

--- a/sondare/services/ndp.py
+++ b/sondare/services/ndp.py
@@ -16,7 +16,7 @@ _ALL_NODES_ADDR = "ff02::1"
 class Ndp:
     """Discovers IPv6 hosts on the local link via ICMPv6 multicast ping + NDP neighbor cache."""
 
-    def __init__(self, verbose: bool, timeout: int, resolve_hostname: bool = False) -> None:
+    def __init__(self, verbose: bool, timeout: float, resolve_hostname: bool = False) -> None:
         self.verbose = verbose
         self.timeout = timeout
         self.resolve_hostname = resolve_hostname

--- a/sondare/services/ndp.py
+++ b/sondare/services/ndp.py
@@ -5,12 +5,8 @@ from scapy.all import Ether, IPv6, ICMPv6EchoRequest, ICMPv6EchoReply, srp
 from sondare.models import Host
 from sondare.utils.network import (
     get_network_interface, get_mac_vendor, get_ipv6_link_local,
-    read_ndp_cache, resolve_hostnames,
+    read_ndp_cache, resolve_hostnames, IPV6_ALL_NODES_MAC, IPV6_ALL_NODES_ADDR,
 )
-
-# Ethernet and IPv6 all-nodes multicast addresses (RFC 4291 §2.7.1).
-_ALL_NODES_MAC  = "33:33:00:00:00:01"
-_ALL_NODES_ADDR = "ff02::1"
 
 
 class Ndp:
@@ -31,11 +27,11 @@ class Ndp:
         local_ip = (get_ipv6_link_local(iface) or "").lower()
 
         pkt = (
-            Ether(dst=_ALL_NODES_MAC) /
-            IPv6(dst=_ALL_NODES_ADDR) /
+            Ether(dst=IPV6_ALL_NODES_MAC) /
+            IPv6(dst=IPV6_ALL_NODES_ADDR) /
             ICMPv6EchoRequest(id=0x5afe, seq=1)
         )
-        print(f"Scanning {_ALL_NODES_ADDR} on {iface} ...", end=" ", flush=True)
+        print(f"Scanning {IPV6_ALL_NODES_ADDR} on {iface} ...", end=" ", flush=True)
         answer = srp(
             pkt,
             iface=iface,

--- a/sondare/services/tcp.py
+++ b/sondare/services/tcp.py
@@ -30,7 +30,8 @@ class Tcp:
         self._lock = threading.Lock()
         self.q: Queue[int] = Queue()
 
-        self.open_ports: list[Port] = []
+        self._open_ports: list[Port] = []
+        self._results: list[Port] = []
         self._done = 0
         self._total = port_end - port_begin + 1
 
@@ -61,7 +62,7 @@ class Tcp:
                 if rsp.getlayer(TCP).flags == 0x12:  # SYN-ACK: open
                     sr(ip_layer / TCP(sport=source_port, dport=target_port, flags="R"), timeout=1, verbose=False, promisc=False)
                     with self._lock:
-                        self.open_ports.append(Port(ip=self.ip, port=target_port))
+                        self._open_ports.append(Port(ip=self.ip, port=target_port))
                 return  # RST or anything else: definitive answer, stop retrying
 
     def _threader(self) -> None:
@@ -92,11 +93,15 @@ class Tcp:
         print()
 
         if self.banners:
-            self.open_ports = [
+            self._open_ports = [
                 Port(ip=p.ip, port=p.port, banner=grab_banner(p.ip, p.port, self._timeout))
-                for p in self.open_ports
+                for p in self._open_ports
             ]
 
+        self._results = [
+            Port(ip=p.ip, port=p.port, banner=p.banner, service=get_port_service(p.port))
+            for p in sorted(self._open_ports, key=lambda p: p.port)
+        ]
+
     def get_results(self) -> list[Port]:
-        """Returns open ports discovered by scan(), sorted by port number."""
-        return [Port(ip=p.ip, port=p.port, banner=p.banner, service=get_port_service(p.port)) for p in sorted(self.open_ports, key=lambda p: p.port)]
+        return self._results

--- a/sondare/services/udp.py
+++ b/sondare/services/udp.py
@@ -26,7 +26,8 @@ class Udp:
         self._lock = threading.Lock()
         self.q: Queue[int] = Queue()
 
-        self.open_ports: list[Port] = []
+        self._open_ports: list[Port] = []
+        self._results: list[Port] = []
         self._done = 0
         self._total = port_end - port_begin + 1
 
@@ -52,7 +53,7 @@ class Udp:
             if rsp is None:
                 if attempt == self.retries:
                     with self._lock:
-                        self.open_ports.append(Port(ip=self.ip, port=target_port))
+                        self._open_ports.append(Port(ip=self.ip, port=target_port))
                 continue
 
             if self._ipv6:
@@ -66,7 +67,7 @@ class Udp:
                         return  # port unreachable — closed
 
             with self._lock:
-                self.open_ports.append(Port(ip=self.ip, port=target_port))
+                self._open_ports.append(Port(ip=self.ip, port=target_port))
             return
 
     def _threader(self) -> None:
@@ -96,6 +97,10 @@ class Udp:
         self.q.join()
         print()
 
+        self._results = [
+            Port(ip=p.ip, port=p.port, service=get_port_service(p.port, "udp"))
+            for p in sorted(self._open_ports, key=lambda p: p.port)
+        ]
+
     def get_results(self) -> list[Port]:
-        """Returns open|filtered ports discovered by scan(), sorted by port number."""
-        return [Port(ip=p.ip, port=p.port, service=get_port_service(p.port, "udp")) for p in sorted(self.open_ports, key=lambda p: p.port)]
+        return self._results

--- a/sondare/utils/network.py
+++ b/sondare/utils/network.py
@@ -8,6 +8,9 @@ import psutil
 from concurrent.futures import ThreadPoolExecutor
 
 
+IPV6_ALL_NODES_MAC  = "33:33:00:00:00:01"
+IPV6_ALL_NODES_ADDR = "ff02::1"
+
 _MDNS_SCAN_SERVICES = [
     "_http._tcp.local.",
     "_https._tcp.local.",

--- a/tests/test_main_output.py
+++ b/tests/test_main_output.py
@@ -105,7 +105,7 @@ class TestPingJsonOutput:
 
         output = capsys.readouterr().out
         parsed = json.loads(output.strip().splitlines()[-1])
-        assert parsed == {"hosts": ["192.168.1.2", "192.168.1.5"]}
+        assert parsed == {"hosts": [{"ip": "192.168.1.2"}, {"ip": "192.168.1.5"}]}
 
     def test_no_json_flag_prints_alive(self, capsys):
         args = _args(scan_method="ping", json=False, resolve_hostname=False)

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -31,7 +31,7 @@ class TestCheckPort:
              patch("random.randint", return_value=54321):
             scanner.check_port(80)
 
-        assert Port(ip="10.0.0.1", port=80) in scanner.open_ports
+        assert Port(ip="10.0.0.1", port=80) in scanner._open_ports
 
     def test_syn_ack_sends_rst(self):
         scanner = _make_scanner()
@@ -48,7 +48,7 @@ class TestCheckPort:
              patch("sondare.services.tcp.sr"):
             scanner.check_port(80)
 
-        assert scanner.open_ports == []
+        assert scanner._open_ports == []
 
     def test_rst_stops_retrying(self):
         scanner = _make_scanner(retries=3)
@@ -65,7 +65,7 @@ class TestCheckPort:
             scanner.check_port(80)
 
         assert mock_sr1.call_count == 3
-        assert scanner.open_ports == []
+        assert scanner._open_ports == []
 
     def test_none_then_syn_ack_adds_port(self):
         scanner = _make_scanner(retries=2)
@@ -75,7 +75,7 @@ class TestCheckPort:
              patch("random.randint", return_value=54321):
             scanner.check_port(80)
 
-        assert Port(ip="10.0.0.1", port=80) in scanner.open_ports
+        assert Port(ip="10.0.0.1", port=80) in scanner._open_ports
 
 
 class TestGetResults:
@@ -83,28 +83,23 @@ class TestGetResults:
         scanner = _make_scanner()
         assert scanner.get_results() == []
 
-    def test_returns_open_ports_after_check(self):
-        scanner = _make_scanner(port_begin=22, port_end=80)
-        with patch("sondare.services.tcp.sr1", side_effect=[
-            _tcp_response(SYN_ACK),  # port 22 open
-            _tcp_response(RST),      # port 80 closed (skipping range interior)
-            _tcp_response(SYN_ACK),  # port 80 open
-        ]), patch("sondare.services.tcp.sr"), \
-           patch("random.randint", return_value=54321):
-            scanner.check_port(22)
-            scanner.check_port(443)
-            scanner.check_port(80)
-
-        assert set(scanner.get_results()) == {Port("10.0.0.1", 22, service="ssh"), Port("10.0.0.1", 80, service="http")}
-
-    def test_results_sorted_by_port(self):
-        scanner = _make_scanner(port_begin=22, port_end=443)
+    def test_get_results_after_scan_includes_service_name(self):
+        scanner = _make_scanner(port_begin=80, port_end=80)
         with patch("sondare.services.tcp.sr1", return_value=_tcp_response(SYN_ACK)), \
              patch("sondare.services.tcp.sr"), \
+             patch("sondare.services.tcp.warm_arp_cache"), \
              patch("random.randint", return_value=54321):
-            scanner.check_port(443)
-            scanner.check_port(22)
-            scanner.check_port(80)
+            scanner.scan()
+
+        assert scanner.get_results() == [Port("10.0.0.1", 80, service="http")]
+
+    def test_results_sorted_by_port(self):
+        scanner = _make_scanner(port_begin=22, port_end=80)
+        with patch("sondare.services.tcp.sr1", return_value=_tcp_response(SYN_ACK)), \
+             patch("sondare.services.tcp.sr"), \
+             patch("sondare.services.tcp.warm_arp_cache"), \
+             patch("random.randint", return_value=54321):
+            scanner.scan()
 
         ports = [p.port for p in scanner.get_results()]
         assert ports == sorted(ports)
@@ -228,7 +223,7 @@ class TestBannersIntegration:
             scanner.scan()
 
         mock_grab.assert_called_once_with("10.0.0.1", 80, scanner._timeout)
-        assert scanner.open_ports == [Port(ip="10.0.0.1", port=80, banner="SSH-2.0-OpenSSH_8.9")]
+        assert scanner._open_ports == [Port(ip="10.0.0.1", port=80, banner="SSH-2.0-OpenSSH_8.9")]
 
     def test_no_banners_flag_leaves_banner_none(self):
         scanner = _make_scanner(banners=False)
@@ -240,7 +235,7 @@ class TestBannersIntegration:
             scanner.scan()
 
         mock_grab.assert_not_called()
-        assert scanner.open_ports == [Port(ip="10.0.0.1", port=80, banner=None)]
+        assert scanner._open_ports == [Port(ip="10.0.0.1", port=80, banner=None)]
 
 
 class TestIpv6Tcp:

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -35,21 +35,21 @@ class TestCheckPort:
         with patch("sondare.services.udp.sr1", return_value=_icmp_response(PORT_UNREACHABLE_TYPE, PORT_UNREACHABLE_CODE)):
             scanner.check_port(53)
 
-        assert scanner.open_ports == []
+        assert scanner._open_ports == []
 
     def test_icmp_other_type_marks_open(self):
         scanner = _make_scanner()
         with patch("sondare.services.udp.sr1", return_value=_icmp_response(3, 1)):  # net unreachable, not port
             scanner.check_port(53)
 
-        assert Port(ip="10.0.0.1", port=53) in scanner.open_ports
+        assert Port(ip="10.0.0.1", port=53) in scanner._open_ports
 
     def test_udp_response_marks_open(self):
         scanner = _make_scanner()
         with patch("sondare.services.udp.sr1", return_value=_udp_response()):
             scanner.check_port(53)
 
-        assert Port(ip="10.0.0.1", port=53) in scanner.open_ports
+        assert Port(ip="10.0.0.1", port=53) in scanner._open_ports
 
     def test_no_response_exhausts_retries_then_marks_open_filtered(self):
         scanner = _make_scanner(retries=2)
@@ -57,7 +57,7 @@ class TestCheckPort:
             scanner.check_port(53)
 
         assert mock_sr1.call_count == 3  # initial + 2 retries
-        assert Port(ip="10.0.0.1", port=53) in scanner.open_ports
+        assert Port(ip="10.0.0.1", port=53) in scanner._open_ports
 
     def test_no_response_does_not_add_port_until_retries_exhausted(self):
         scanner = _make_scanner(retries=2)
@@ -73,7 +73,7 @@ class TestCheckPort:
         with patch("sondare.services.udp.sr1", side_effect=side_effect):
             scanner.check_port(53)
 
-        assert scanner.open_ports == []  # closed on last attempt
+        assert scanner._open_ports == []  # closed on last attempt
 
     def test_icmp_unreachable_stops_retrying(self):
         scanner = _make_scanner(retries=3)
@@ -81,7 +81,7 @@ class TestCheckPort:
             scanner.check_port(53)
 
         assert mock_sr1.call_count == 1
-        assert scanner.open_ports == []
+        assert scanner._open_ports == []
 
     def test_udp_response_stops_retrying(self):
         scanner = _make_scanner(retries=3)
@@ -89,7 +89,7 @@ class TestCheckPort:
             scanner.check_port(53)
 
         assert mock_sr1.call_count == 1
-        assert Port(ip="10.0.0.1", port=53) in scanner.open_ports
+        assert Port(ip="10.0.0.1", port=53) in scanner._open_ports
 
 
 class TestGetResults:
@@ -97,29 +97,19 @@ class TestGetResults:
         scanner = _make_scanner()
         assert scanner.get_results() == []
 
-    def test_returns_open_filtered_ports_after_check(self):
-        scanner = _make_scanner(port_begin=53, port_end=69)
-        responses = {
-            53: None,                                                            # open|filtered
-            54: _icmp_response(PORT_UNREACHABLE_TYPE, PORT_UNREACHABLE_CODE),   # closed
-            69: _udp_response(),                                                 # open
-        }
+    def test_get_results_after_scan_includes_service_name(self):
+        scanner = _make_scanner(port_begin=53, port_end=53)
+        with patch("sondare.services.udp.sr1", return_value=None), \
+             patch("sondare.services.udp.warm_arp_cache"):
+            scanner.scan()
 
-        for port, rsp in responses.items():
-            with patch("sondare.services.udp.sr1", return_value=rsp):
-                scanner.check_port(port)
-
-        assert set(scanner.get_results()) == {Port("10.0.0.1", 53, service="domain"), Port("10.0.0.1", 69, service="tftp")}
+        assert scanner.get_results() == [Port("10.0.0.1", 53, service="domain")]
 
     def test_results_sorted_by_port(self):
-        scanner = _make_scanner(port_begin=53, port_end=123)
-        responses = {
-            123: None,            # open|filtered (NTP)
-            53: _udp_response(),  # open (DNS)
-        }
-        for port, rsp in responses.items():
-            with patch("sondare.services.udp.sr1", return_value=rsp):
-                scanner.check_port(port)
+        scanner = _make_scanner(port_begin=53, port_end=69)
+        with patch("sondare.services.udp.sr1", return_value=None), \
+             patch("sondare.services.udp.warm_arp_cache"):
+            scanner.scan()
 
         ports = [p.port for p in scanner.get_results()]
         assert ports == sorted(ports)
@@ -151,7 +141,7 @@ class TestIpv6Udp:
              patch("sondare.services.udp.warm_arp_cache"):
             scanner.check_port(53)
 
-        assert scanner.open_ports == []
+        assert scanner._open_ports == []
 
     def test_ipv6_scan_skips_arp_cache(self):
         scanner = Udp(verbose=False, ip="fe80::1", port_begin=53, port_end=53,


### PR DESCRIPTION
## Summary

This PR brings some code and output format refactoring as a patch version

## Changes

- Fixed hardcoded paddings for `trace`, `mdns` and `monitor arp`
- `ping` now returns objects instead of raw strings for `--resolve_hostname` flag
- Refactored `get_results()` for `arp`, `tcp` and `udp`
- Fixed timeout types from int to float for `arp` and `ndp`
- Extracted `IPV6_ALL_NODES_MAC` and `IPV6_ALL_NODES_ADDR` as a global constants for IPv6 stack

## Testing

All tests are landed in tests/ folder. Results are depicted in tests action

## Related issues

No related issues present